### PR TITLE
Add TypeIdModule to httpclient's Json objectMapper

### DIFF
--- a/httpclient/src/main/kotlin/tbdex/sdk/httpclient/Json.kt
+++ b/httpclient/src/main/kotlin/tbdex/sdk/httpclient/Json.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectWriter
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import tbdex.sdk.protocol.serialization.TypeIdModule
 
 /**
  * A singleton object for handling JSON operations,
@@ -17,6 +18,7 @@ object Json {
   val objectMapper: ObjectMapper = ObjectMapper()
     .registerKotlinModule()
     .findAndRegisterModules()
+    .registerModule(TypeIdModule())
     .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
   private val objectWriter: ObjectWriter = objectMapper.writer()


### PR DESCRIPTION
Was causing an error to be thrown 

```
com.fasterxml.jackson.databind.exc.ValueInstantiationException: Cannot construct instance of `typeid.TypeID`, problem: offering_01hd46f81tf1989rgnfccjv63v is not a valid prefix
 at [Source: (String)"[{"metadata":{"from":"did:ion:EiC_tpTAKoHLW2Z2CJ9plAMbFAOoWR8CgAqQzCdADcL5TQ:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiJkd24tc2lnIiwicHVibGljS2V5SndrIjp7ImNydiI6IkVkMjU1MTkiLCJrdHkiOiJPS1AiLCJ4IjoiSW1MSnRDT01CTE5INHF5aXVrdVFIdlZobkE2OGtZZTU2V0RlY214RzBGWSJ9LCJwdXJwb3NlcyI6WyJhdXRoZW50aWNhdGlvbiJdLCJ0eXBlIjoiSnNvbldlYktleTIwMjAifV0sInNlcnZpY2VzIjpbeyJpZCI6InBmaSIsInNlcnZpY2VFbmRwb2ludCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMCIsInR5cGUiOiJQRkkifV19fV0"[truncated 3228 chars]; line: 1, column: 814] (through reference chain: java.util.ArrayList[0]->tbdex.sdk.protocol.models.Offering["metadata"]->tbdex.sdk.protocol.models.ResourceMetadata["id"])
```