### PR TITLE
Publish prep

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,9 +46,16 @@ subprojects {
     config.setFrom("$rootDir/config/detekt.yml")
   }
 
+  kotlin {
+    jvmToolchain(17)
+  }
+
   java {
     withJavadocJar()
     withSourcesJar()
+
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
   }
 
   publishing {

--- a/httpclient/build.gradle.kts
+++ b/httpclient/build.gradle.kts
@@ -3,8 +3,6 @@ plugins {
   id("java-library")
 }
 
-version = "1.0"
-
 repositories {
   mavenCentral()
   maven {

--- a/httpclient/build.gradle.kts
+++ b/httpclient/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.8")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
-  implementation("com.github.TBD54566975:web5-kt:0.0.4-beta")
+  implementation("com.github.TBD54566975:web5-kt:0.0.5-beta")
   implementation("decentralized-identity:did-common-java:1.9.0") // would like to grab this via web5 dids
 
   testImplementation(kotlin("test"))

--- a/httpserver/build.gradle.kts
+++ b/httpserver/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
   id("idea")
 }
 
-version = "1.0"
 var ktorVersion = "2.3.4"
 
 repositories {

--- a/httpserver/src/main/kotlin/tbdex/sdk/httpserver/Server.kt
+++ b/httpserver/src/main/kotlin/tbdex/sdk/httpserver/Server.kt
@@ -1,4 +1,4 @@
-package tbdex.server.tbdex.sdk.http_server
+package tbdex.sdk.httpserver
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application

--- a/httpserver/src/test/kotlin/tbdex/sdk/httpserver/ServerTest.kt
+++ b/httpserver/src/test/kotlin/tbdex/sdk/httpserver/ServerTest.kt
@@ -6,7 +6,6 @@ import io.ktor.server.application.Application
 import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.withTestApplication
 import org.junit.jupiter.api.Test
-import tbdex.server.tbdex.sdk.http_server.module
 import kotlin.test.assertEquals
 
 class ServerTest {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17

--- a/protocol/build.gradle.kts
+++ b/protocol/build.gradle.kts
@@ -3,8 +3,6 @@ plugins {
   id("java-library")
 }
 
-version = "1.0"
-
 repositories {
   mavenCentral()
   maven {

--- a/protocol/build.gradle.kts
+++ b/protocol/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.8")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-json-org:2.11.0")
-  implementation("com.github.TBD54566975:web5-kt:0.0.4-beta")
+  implementation("com.github.TBD54566975:web5-kt:0.0.5-beta")
   implementation("com.networknt:json-schema-validator:1.0.87")
   implementation("com.nimbusds:nimbus-jose-jwt:9.36")
   implementation("decentralized-identity:did-common-java:1.9.0")

--- a/protocol/build.gradle.kts
+++ b/protocol/build.gradle.kts
@@ -14,7 +14,8 @@ repositories {
 }
 
 dependencies {
-  implementation("me.lessis:typeid:0.0.2")
+  api("me.lessis:typeid:0.0.2")
+
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.8")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-json-org:2.11.0")

--- a/protocol/src/main/kotlin/tbdex/sdk/protocol/CryptoUtils.kt
+++ b/protocol/src/main/kotlin/tbdex/sdk/protocol/CryptoUtils.kt
@@ -51,7 +51,7 @@ object CryptoUtils {
     // or just `#fragment`. See: https://www.w3.org/TR/did-core/#relative-did-urls.
     // Using a set for fast string comparison. DIDs can be long.
     val verificationMethodIds = setOf(parsedDidUrl.didUrlString, "#${parsedDidUrl.fragment}")
-    val assertionMethods = didResolutionResult.didDocument.assertionMethodVerificationMethodsDereferenced
+    val assertionMethods = didResolutionResult.didDocument.assertionMethodVerificationMethodsDereferenced ?: listOf()
     var assertionMethod: VerificationMethod? = null
 
     for (method in assertionMethods) {

--- a/protocol/src/main/kotlin/tbdex/sdk/protocol/CryptoUtils.kt
+++ b/protocol/src/main/kotlin/tbdex/sdk/protocol/CryptoUtils.kt
@@ -51,7 +51,7 @@ object CryptoUtils {
     // or just `#fragment`. See: https://www.w3.org/TR/did-core/#relative-did-urls.
     // Using a set for fast string comparison. DIDs can be long.
     val verificationMethodIds = setOf(parsedDidUrl.didUrlString, "#${parsedDidUrl.fragment}")
-    val assertionMethods = didResolutionResult.didDocument.assertionMethodVerificationMethodsDereferenced ?: listOf()
+    val assertionMethods = didResolutionResult.didDocument.assertionMethodVerificationMethodsDereferenced ?: emptyList()
     var assertionMethod: VerificationMethod? = null
 
     for (method in assertionMethods) {

--- a/protocol/src/main/kotlin/tbdex/sdk/protocol/models/Message.kt
+++ b/protocol/src/main/kotlin/tbdex/sdk/protocol/models/Message.kt
@@ -11,6 +11,7 @@ import tbdex.sdk.protocol.serialization.Json.jsonMapper
 import tbdex.sdk.protocol.serialization.dateTimeFormat
 import typeid.TypeID
 import web5.sdk.dids.Did
+import java.security.MessageDigest
 import java.time.OffsetDateTime
 
 /**
@@ -75,7 +76,8 @@ sealed class Message {
     val payload = mapOf("metadata" to this.metadata, "data" to this.data)
     val canonicalJsonSerializedPayload = JsonCanonicalizer(Json.stringify(payload))
 
-    return canonicalJsonSerializedPayload.encodedUTF8
+    val sha256 = MessageDigest.getInstance("SHA-256")
+    return sha256.digest(canonicalJsonSerializedPayload.encodedUTF8)
   }
 
   /**

--- a/protocol/src/main/kotlin/tbdex/sdk/protocol/models/Resource.kt
+++ b/protocol/src/main/kotlin/tbdex/sdk/protocol/models/Resource.kt
@@ -11,6 +11,7 @@ import tbdex.sdk.protocol.serialization.Json.jsonMapper
 import tbdex.sdk.protocol.serialization.dateTimeFormat
 import typeid.TypeID
 import web5.sdk.dids.Did
+import java.security.MessageDigest
 import java.time.OffsetDateTime
 
 /**
@@ -73,7 +74,8 @@ sealed class Resource {
     val payload = mapOf("metadata" to this.metadata, "data" to this.data)
     val canonicalJsonSerializedPayload = JsonCanonicalizer(Json.stringify(payload))
 
-    return canonicalJsonSerializedPayload.encodedUTF8
+    val sha256 = MessageDigest.getInstance("SHA-256")
+    return sha256.digest(canonicalJsonSerializedPayload.encodedUTF8)
   }
 
   /**

--- a/protocol/src/test/resources/testVectors.json
+++ b/protocol/src/test/resources/testVectors.json
@@ -3,10 +3,10 @@
     "offering": {
       "metadata": {
         "kind": "offering",
-        "from": "did:key:zQ3shwAYN63R4UHiKsVg3f3vG4RafNxAD4kpBR2Px8JT7dDj1",
-        "id": "offering_01hdgc6qfze80r000204001fpx",
-        "createdAt": "2023-10-24T08:18:18.214Z",
-        "updatedAt": "2023-10-24T08:18:18.214Z"
+        "from": "did:key:zQ3shhwZ18aebLvYzCDdkkUH78z6RXec843BQc9hybsMRSoxg",
+        "id": "offering_01hdh7fyftfkv8002wyr000nj5",
+        "createdAt": "2023-10-24T16:15:03.662Z",
+        "updatedAt": "2023-10-24T16:15:03.662Z"
       },
       "data": {
         "description": "A sample offering",
@@ -85,7 +85,7 @@
           "id": "test-pd-id",
           "name": "simple PD",
           "purpose": "pd for testing",
-          "inputDescriptors": [
+          "input_descriptors": [
             {
               "id": "whatever",
               "purpose": "id for testing",
@@ -102,21 +102,21 @@
           ]
         }
       },
-      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3Nod0FZTjYzUjRVSGlLc1ZnM2Yzdkc0UmFmTnhBRDRrcEJSMlB4OEpUN2REajEjelEzc2h3QVlONjNSNFVIaUtzVmczZjN2RzRSYWZOeEFENGtwQlIyUHg4SlQ3ZERqMSIsImFsZyI6IkVTMjU2SyJ9..d7JYMtV6UihYpPlbdIg5Lx6Of2ZA9kVgoUhpUckR6Xg9cg5kU7kxxO3HPkMos0cFlBV3x45Iv0YhErgFujVw5A"
+      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NoaHdaMThhZWJMdll6Q0Rka2tVSDc4ejZSWGVjODQzQlFjOWh5YnNNUlNveGcjelEzc2hod1oxOGFlYkx2WXpDRGRra1VINzh6NlJYZWM4NDNCUWM5aHlic01SU294ZyIsImFsZyI6IkVTMjU2SyJ9..MyaMT4LZAlkLj4w9LZMqQLsaklhHlsrob60p1XmKMKg249kweyXPGABpEnvKD_65_1s1RjdyKlEotgQT15xAYw"
     }
   },
   "messages": {
     "rfq": {
       "metadata": {
         "kind": "rfq",
-        "to": "did:key:zQ3shwAYN63R4UHiKsVg3f3vG4RafNxAD4kpBR2Px8JT7dDj1",
-        "from": "did:key:zQ3shujqALzHHaiBqC8Fyq9pYudE774t3ub7zc9HtA3GZ8x5S",
-        "id": "rfq_7zzzzzzzzff0er00683m0006gn",
-        "exchangeId": "rfq_7zzzzzzzzff0er00683m0006gn",
-        "createdAt": "2023-10-24T08:18:18.570Z"
+        "to": "did:key:zQ3shhwZ18aebLvYzCDdkkUH78z6RXec843BQc9hybsMRSoxg",
+        "from": "did:key:zQ3shizfQYEiB8dqac96P6SHYtUCCsY7gSci4Qeaebgsfz1VC",
+        "id": "rfq_7zzzzzzyzte028007g0g001xdc",
+        "exchangeId": "rfq_7zzzzzzyzte028007g0g001xdc",
+        "createdAt": "2023-10-24T16:15:04.010Z"
       },
       "data": {
-        "offeringId": "offering_7zzzzzzzyxfny8000xfg0001v7",
+        "offeringId": "offering_01hdh7fyzzek48003ms0001bv2",
         "payinSubunits": "1000",
         "payinMethod": {
           "kind": "BTC_ADDRESS",
@@ -135,19 +135,19 @@
           "presentation submission"
         ]
       },
-      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NodWpxQUx6SEhhaUJxQzhGeXE5cFl1ZEU3NzR0M3ViN3pjOUh0QTNHWjh4NVMjelEzc2h1anFBTHpISGFpQnFDOEZ5cTlwWXVkRTc3NHQzdWI3emM5SHRBM0daOHg1UyIsImFsZyI6IkVTMjU2SyJ9..GMY9UE62e3_U5aE7ZXmW2kTvurR2HY4SePLK4hAkCsIIZ1PSOfOJzGg1qrriJ-XpccXkDjaEJXtVTd70aqdOsQ"
+      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NoaXpmUVlFaUI4ZHFhYzk2UDZTSFl0VUNDc1k3Z1NjaTRRZWFlYmdzZnoxVkMjelEzc2hpemZRWUVpQjhkcWFjOTZQNlNIWXRVQ0NzWTdnU2NpNFFlYWViZ3NmejFWQyIsImFsZyI6IkVTMjU2SyJ9..Y9gKs87CGalvHxlChHsL2fx2wtlPbY2-tBDciz7rSKRJkWmeIdyu-7NxwUdVMlQfJ58PTLoYPknXUKL8Hc0v4w"
     },
     "quote": {
       "metadata": {
         "kind": "quote",
-        "to": "did:key:zQ3shujqALzHHaiBqC8Fyq9pYudE774t3ub7zc9HtA3GZ8x5S",
-        "from": "did:key:zQ3shwAYN63R4UHiKsVg3f3vG4RafNxAD4kpBR2Px8JT7dDj1",
-        "id": "quote_01hdgc6zyzfwrr002f640018ha",
-        "exchangeId": "rfq_7zzzzzzqvqe81r00620c001m5x",
-        "createdAt": "2023-10-24T08:18:18.584Z"
+        "to": "did:key:zQ3shizfQYEiB8dqac96P6SHYtUCCsY7gSci4Qeaebgsfz1VC",
+        "from": "did:key:zQ3shhwZ18aebLvYzCDdkkUH78z6RXec843BQc9hybsMRSoxg",
+        "id": "quote_7zzzzzzpyrfy2r004fgm0013c7",
+        "exchangeId": "rfq_7zzzzzzzztfxx8001ff8000ex2",
+        "createdAt": "2023-10-24T16:15:04.024Z"
       },
       "data": {
-        "expiresAt": "2023-10-25T08:18:18.583Z",
+        "expiresAt": "2023-10-25T16:15:04.024Z",
         "payin": {
           "currencyCode": "AUD",
           "amountSubunits": "1000",
@@ -169,47 +169,47 @@
           }
         }
       },
-      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3Nod0FZTjYzUjRVSGlLc1ZnM2Yzdkc0UmFmTnhBRDRrcEJSMlB4OEpUN2REajEjelEzc2h3QVlONjNSNFVIaUtzVmczZjN2RzRSYWZOeEFENGtwQlIyUHg4SlQ3ZERqMSIsImFsZyI6IkVTMjU2SyJ9..SPblIoetEci1Yo_BxCn_94nwaHoWNrNlb2Nh25w_zmATcZhDgQQsNS5aZhBLqvcr_ntVR-3od1LA87Z__Scwrw"
+      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NoaHdaMThhZWJMdll6Q0Rka2tVSDc4ejZSWGVjODQzQlFjOWh5YnNNUlNveGcjelEzc2hod1oxOGFlYkx2WXpDRGRra1VINzh6NlJYZWM4NDNCUWM5aHlic01SU294ZyIsImFsZyI6IkVTMjU2SyJ9..B2n8TL3Tk_Bq0uf8l-1IIj_p44fuLghihElbrF493N1b1TqexdHqkhUuevdh5DKsTi3DgiQyHd8Vijwnz6Ap_A"
     },
     "order": {
       "metadata": {
         "kind": "order",
-        "to": "did:key:zQ3shwAYN63R4UHiKsVg3f3vG4RafNxAD4kpBR2Px8JT7dDj1",
-        "from": "did:key:zQ3shujqALzHHaiBqC8Fyq9pYudE774t3ub7zc9HtA3GZ8x5S",
-        "id": "order_01hdgc6zzrfa7r002ahw001rn2",
-        "exchangeId": "rfq_7zzzzzzzv8ed88007ka0000vft",
-        "createdAt": "2023-10-24T08:18:18.592Z"
+        "to": "did:key:zQ3shhwZ18aebLvYzCDdkkUH78z6RXec843BQc9hybsMRSoxg",
+        "from": "did:key:zQ3shizfQYEiB8dqac96P6SHYtUCCsY7gSci4Qeaebgsfz1VC",
+        "id": "order_01hdh7fpzjeh980014a8000t9d",
+        "exchangeId": "rfq_7zzzzzzqvhffw8002vz0000mwp",
+        "createdAt": "2023-10-24T16:15:04.032Z"
       },
       "data": {},
-      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NodWpxQUx6SEhhaUJxQzhGeXE5cFl1ZEU3NzR0M3ViN3pjOUh0QTNHWjh4NVMjelEzc2h1anFBTHpISGFpQnFDOEZ5cTlwWXVkRTc3NHQzdWI3emM5SHRBM0daOHg1UyIsImFsZyI6IkVTMjU2SyJ9..PfMKeGcBqCoEMUZSein153a1_nxP7vIhpQAz95LhnzpsCstvtGGJeCYcUEFeSfyXR_pELtpzttSg4ySnu07QCQ"
+      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NoaXpmUVlFaUI4ZHFhYzk2UDZTSFl0VUNDc1k3Z1NjaTRRZWFlYmdzZnoxVkMjelEzc2hpemZRWUVpQjhkcWFjOTZQNlNIWXRVQ0NzWTdnU2NpNFFlYWViZ3NmejFWQyIsImFsZyI6IkVTMjU2SyJ9..FLzrqCirBzDFix3AuIpv-1FtGSUNq7v6ckUQjzrGc5JLDSggS8P-MdVJ1gW5SVCusZCRhkjk6UX4qQXSFZ4X8w"
     },
     "orderStatus": {
       "metadata": {
         "kind": "orderstatus",
-        "to": "did:key:zQ3shujqALzHHaiBqC8Fyq9pYudE774t3ub7zc9HtA3GZ8x5S",
-        "from": "did:key:zQ3shwAYN63R4UHiKsVg3f3vG4RafNxAD4kpBR2Px8JT7dDj1",
-        "id": "orderstatus_7zzzzzzzv2fs0r007y84000d1z",
-        "exchangeId": "rfq_01hdgc6zv7ff3r001brw000jpn",
-        "createdAt": "2023-10-24T08:18:18.594Z"
+        "to": "did:key:zQ3shizfQYEiB8dqac96P6SHYtUCCsY7gSci4Qeaebgsfz1VC",
+        "from": "did:key:zQ3shhwZ18aebLvYzCDdkkUH78z6RXec843BQc9hybsMRSoxg",
+        "id": "orderstatus_01hdh7fzvffj3r005wgw000ac4",
+        "exchangeId": "rfq_01hdh7fqvzesf8002pbr001x7t",
+        "createdAt": "2023-10-24T16:15:04.034Z"
       },
       "data": {
         "orderStatus": "PENDING"
       },
-      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3Nod0FZTjYzUjRVSGlLc1ZnM2Yzdkc0UmFmTnhBRDRrcEJSMlB4OEpUN2REajEjelEzc2h3QVlONjNSNFVIaUtzVmczZjN2RzRSYWZOeEFENGtwQlIyUHg4SlQ3ZERqMSIsImFsZyI6IkVTMjU2SyJ9..nkYrhJLM6SthFYTQIksv9Xa1El5g9YG0aKsz75uBU8g9iBpfhKu4iQVBNT2nkUE0CilbjkKnYW5QPB-12RHhEA"
+      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NoaHdaMThhZWJMdll6Q0Rka2tVSDc4ejZSWGVjODQzQlFjOWh5YnNNUlNveGcjelEzc2hod1oxOGFlYkx2WXpDRGRra1VINzh6NlJYZWM4NDNCUWM5aHlic01SU294ZyIsImFsZyI6IkVTMjU2SyJ9..dSZEztUIOWMfb8fLuJSL5A9DblEH7ROszTUztv1b-21dgKEZMCZCAPeju2MEEIObtv7SKvWopenL7IqtP2RpVQ"
     },
     "close": {
       "metadata": {
         "kind": "close",
-        "to": "did:key:zQ3shujqALzHHaiBqC8Fyq9pYudE774t3ub7zc9HtA3GZ8x5S",
-        "from": "did:key:zQ3shwAYN63R4UHiKsVg3f3vG4RafNxAD4kpBR2Px8JT7dDj1",
-        "id": "close_01hdgc6zvzf908006t800009v7",
-        "exchangeId": "rfq_7zzzzzzqvfe1xr007gfc001xkn",
-        "createdAt": "2023-10-24T08:18:18.597Z"
+        "to": "did:key:zQ3shizfQYEiB8dqac96P6SHYtUCCsY7gSci4Qeaebgsfz1VC",
+        "from": "did:key:zQ3shhwZ18aebLvYzCDdkkUH78z6RXec843BQc9hybsMRSoxg",
+        "id": "close_7zzzzzzpvqf2480048h0001jm6",
+        "exchangeId": "rfq_01hdh7fqvpevq8003pxr001a45",
+        "createdAt": "2023-10-24T16:15:04.037Z"
       },
       "data": {
         "reason": "test reason"
       },
-      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3Nod0FZTjYzUjRVSGlLc1ZnM2Yzdkc0UmFmTnhBRDRrcEJSMlB4OEpUN2REajEjelEzc2h3QVlONjNSNFVIaUtzVmczZjN2RzRSYWZOeEFENGtwQlIyUHg4SlQ3ZERqMSIsImFsZyI6IkVTMjU2SyJ9..5lzums4vWjb44UxkcNw2aQPkL9RIT2cN4nNnhhBFLyIHywVGVcbPkWNh3kEKf4DQxwa0oi3zfChggQHCMTkbUg"
+      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NoaHdaMThhZWJMdll6Q0Rka2tVSDc4ejZSWGVjODQzQlFjOWh5YnNNUlNveGcjelEzc2hod1oxOGFlYkx2WXpDRGRra1VINzh6NlJYZWM4NDNCUWM5aHlic01SU294ZyIsImFsZyI6IkVTMjU2SyJ9..TDtaxXdl1Bljuft8bZlvxTXTK472fKOia12kG_mQA7UhGTVIfwO9cuDCS_86EZHPMhkAvYdOnIiUodouZVba_A"
     }
   }
 }

--- a/protocol/src/test/resources/testVectors.json
+++ b/protocol/src/test/resources/testVectors.json
@@ -3,10 +3,10 @@
     "offering": {
       "metadata": {
         "kind": "offering",
-        "from": "did:key:zQ3shYHEKhVFvDDvAEmyCTPB3kRkHZdD8QCbykAPpopj5ng4u",
-        "id": "offering_7zzzzzzwzyf678004shr000zqf",
-        "createdAt": "2023-10-20T19:28:09.594Z",
-        "updatedAt": "2023-10-20T19:28:09.594Z"
+        "from": "did:key:zQ3shwAYN63R4UHiKsVg3f3vG4RafNxAD4kpBR2Px8JT7dDj1",
+        "id": "offering_01hdgc6qfze80r000204001fpx",
+        "createdAt": "2023-10-24T08:18:18.214Z",
+        "updatedAt": "2023-10-24T08:18:18.214Z"
       },
       "data": {
         "description": "A sample offering",
@@ -102,21 +102,21 @@
           ]
         }
       },
-      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NoWUhFS2hWRnZERHZBRW15Q1RQQjNrUmtIWmREOFFDYnlrQVBwb3BqNW5nNHUjelEzc2hZSEVLaFZGdkREdkFFbXlDVFBCM2tSa0haZEQ4UUNieWtBUHBvcGo1bmc0dSIsImFsZyI6IkVTMjU2SyJ9..52s8dGKKDW7-8_qo4Mp1aAtvT6v6r7yQEJY6P8Xo-etFClntFm0031Wyl8a76mS6Wiq_0Zr84_6lAUBYo-rVNw"
+      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3Nod0FZTjYzUjRVSGlLc1ZnM2Yzdkc0UmFmTnhBRDRrcEJSMlB4OEpUN2REajEjelEzc2h3QVlONjNSNFVIaUtzVmczZjN2RzRSYWZOeEFENGtwQlIyUHg4SlQ3ZERqMSIsImFsZyI6IkVTMjU2SyJ9..d7JYMtV6UihYpPlbdIg5Lx6Of2ZA9kVgoUhpUckR6Xg9cg5kU7kxxO3HPkMos0cFlBV3x45Iv0YhErgFujVw5A"
     }
   },
   "messages": {
     "rfq": {
       "metadata": {
         "kind": "rfq",
-        "to": "did:key:zQ3shYHEKhVFvDDvAEmyCTPB3kRkHZdD8QCbykAPpopj5ng4u",
-        "from": "did:key:zQ3shizeS6VFzTasyXFXcLgYaiLN5yK5PQe9v37VYy9yQzXQq",
-        "id": "rfq_7zzzzzzzqke7nr003hxc001mey",
-        "exchangeId": "rfq_7zzzzzzzqke7nr003hxc001mey",
-        "createdAt": "2023-10-20T19:28:09.969Z"
+        "to": "did:key:zQ3shwAYN63R4UHiKsVg3f3vG4RafNxAD4kpBR2Px8JT7dDj1",
+        "from": "did:key:zQ3shujqALzHHaiBqC8Fyq9pYudE774t3ub7zc9HtA3GZ8x5S",
+        "id": "rfq_7zzzzzzzzff0er00683m0006gn",
+        "exchangeId": "rfq_7zzzzzzzzff0er00683m0006gn",
+        "createdAt": "2023-10-24T08:18:18.570Z"
       },
       "data": {
-        "offeringId": "offering_7zzzzzzx7yff7r002bsw001f3s",
+        "offeringId": "offering_7zzzzzzzyxfny8000xfg0001v7",
         "payinSubunits": "1000",
         "payinMethod": {
           "kind": "BTC_ADDRESS",
@@ -135,19 +135,19 @@
           "presentation submission"
         ]
       },
-      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NoaXplUzZWRnpUYXN5WEZYY0xnWWFpTE41eUs1UFFlOXYzN1ZZeTl5UXpYUXEjelEzc2hpemVTNlZGelRhc3lYRlhjTGdZYWlMTjV5SzVQUWU5djM3Vll5OXlRelhRcSIsImFsZyI6IkVTMjU2SyJ9.._lWN41pV9Vi9emli0c6ZyYq-D1Jvx6padYxnb9Zneh1aXgCAracsCf_ehemi7OLK5GaV0Kp0JX688DQp1SUe-A"
+      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NodWpxQUx6SEhhaUJxQzhGeXE5cFl1ZEU3NzR0M3ViN3pjOUh0QTNHWjh4NVMjelEzc2h1anFBTHpISGFpQnFDOEZ5cTlwWXVkRTc3NHQzdWI3emM5SHRBM0daOHg1UyIsImFsZyI6IkVTMjU2SyJ9..GMY9UE62e3_U5aE7ZXmW2kTvurR2HY4SePLK4hAkCsIIZ1PSOfOJzGg1qrriJ-XpccXkDjaEJXtVTd70aqdOsQ"
     },
     "quote": {
       "metadata": {
         "kind": "quote",
-        "to": "did:key:zQ3shizeS6VFzTasyXFXcLgYaiLN5yK5PQe9v37VYy9yQzXQq",
-        "from": "did:key:zQ3shYHEKhVFvDDvAEmyCTPB3kRkHZdD8QCbykAPpopj5ng4u",
-        "id": "quote_7zzzzzzz7zfj1r006cgc000c6d",
-        "exchangeId": "rfq_7zzzzzzd7zfwzr006f7w000tbk",
-        "createdAt": "2023-10-20T19:28:09.981Z"
+        "to": "did:key:zQ3shujqALzHHaiBqC8Fyq9pYudE774t3ub7zc9HtA3GZ8x5S",
+        "from": "did:key:zQ3shwAYN63R4UHiKsVg3f3vG4RafNxAD4kpBR2Px8JT7dDj1",
+        "id": "quote_01hdgc6zyzfwrr002f640018ha",
+        "exchangeId": "rfq_7zzzzzzqvqe81r00620c001m5x",
+        "createdAt": "2023-10-24T08:18:18.584Z"
       },
       "data": {
-        "expiresAt": "2023-10-21T19:28:09.981Z",
+        "expiresAt": "2023-10-25T08:18:18.583Z",
         "payin": {
           "currencyCode": "AUD",
           "amountSubunits": "1000",
@@ -169,47 +169,47 @@
           }
         }
       },
-      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NoWUhFS2hWRnZERHZBRW15Q1RQQjNrUmtIWmREOFFDYnlrQVBwb3BqNW5nNHUjelEzc2hZSEVLaFZGdkREdkFFbXlDVFBCM2tSa0haZEQ4UUNieWtBUHBvcGo1bmc0dSIsImFsZyI6IkVTMjU2SyJ9..gl6vcasltpykqtIavynximjLKq41qPqlbZYmtg0AKu8OfTqOZvdjzmCzjMNMs8D6baZrSEfuyVLRq0medNA7CQ"
+      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3Nod0FZTjYzUjRVSGlLc1ZnM2Yzdkc0UmFmTnhBRDRrcEJSMlB4OEpUN2REajEjelEzc2h3QVlONjNSNFVIaUtzVmczZjN2RzRSYWZOeEFENGtwQlIyUHg4SlQ3ZERqMSIsImFsZyI6IkVTMjU2SyJ9..SPblIoetEci1Yo_BxCn_94nwaHoWNrNlb2Nh25w_zmATcZhDgQQsNS5aZhBLqvcr_ntVR-3od1LA87Z__Scwrw"
     },
     "order": {
       "metadata": {
         "kind": "order",
-        "to": "did:key:zQ3shYHEKhVFvDDvAEmyCTPB3kRkHZdD8QCbykAPpopj5ng4u",
-        "from": "did:key:zQ3shizeS6VFzTasyXFXcLgYaiLN5yK5PQe9v37VYy9yQzXQq",
-        "id": "order_7zzzzzzf9pf478000s1r00130t",
-        "exchangeId": "rfq_01hd78yxvcf71r0029rc001xcz",
-        "createdAt": "2023-10-20T19:28:09.988Z"
+        "to": "did:key:zQ3shwAYN63R4UHiKsVg3f3vG4RafNxAD4kpBR2Px8JT7dDj1",
+        "from": "did:key:zQ3shujqALzHHaiBqC8Fyq9pYudE774t3ub7zc9HtA3GZ8x5S",
+        "id": "order_01hdgc6zzrfa7r002ahw001rn2",
+        "exchangeId": "rfq_7zzzzzzzv8ed88007ka0000vft",
+        "createdAt": "2023-10-24T08:18:18.592Z"
       },
       "data": {},
-      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NoaXplUzZWRnpUYXN5WEZYY0xnWWFpTE41eUs1UFFlOXYzN1ZZeTl5UXpYUXEjelEzc2hpemVTNlZGelRhc3lYRlhjTGdZYWlMTjV5SzVQUWU5djM3Vll5OXlRelhRcSIsImFsZyI6IkVTMjU2SyJ9..pgQBsE39vG93VjmwHNzRzFc9OiXgOBhKIOorulVtuPhj9k-Ck4-k9naUtCIjR0MuQYeSbwOmtrGGKwJ-4EGjRw"
+      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NodWpxQUx6SEhhaUJxQzhGeXE5cFl1ZEU3NzR0M3ViN3pjOUh0QTNHWjh4NVMjelEzc2h1anFBTHpISGFpQnFDOEZ5cTlwWXVkRTc3NHQzdWI3emM5SHRBM0daOHg1UyIsImFsZyI6IkVTMjU2SyJ9..PfMKeGcBqCoEMUZSein153a1_nxP7vIhpQAz95LhnzpsCstvtGGJeCYcUEFeSfyXR_pELtpzttSg4ySnu07QCQ"
     },
     "orderStatus": {
       "metadata": {
         "kind": "orderstatus",
-        "to": "did:key:zQ3shizeS6VFzTasyXFXcLgYaiLN5yK5PQe9v37VYy9yQzXQq",
-        "from": "did:key:zQ3shYHEKhVFvDDvAEmyCTPB3kRkHZdD8QCbykAPpopj5ng4u",
-        "id": "orderstatus_01hd78yz9ffv28003yrg001kwm",
-        "exchangeId": "rfq_7zzzzzzzfqe6zr002hqw00001x",
-        "createdAt": "2023-10-20T19:28:09.991Z"
+        "to": "did:key:zQ3shujqALzHHaiBqC8Fyq9pYudE774t3ub7zc9HtA3GZ8x5S",
+        "from": "did:key:zQ3shwAYN63R4UHiKsVg3f3vG4RafNxAD4kpBR2Px8JT7dDj1",
+        "id": "orderstatus_7zzzzzzzv2fs0r007y84000d1z",
+        "exchangeId": "rfq_01hdgc6zv7ff3r001brw000jpn",
+        "createdAt": "2023-10-24T08:18:18.594Z"
       },
       "data": {
         "orderStatus": "PENDING"
       },
-      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NoWUhFS2hWRnZERHZBRW15Q1RQQjNrUmtIWmREOFFDYnlrQVBwb3BqNW5nNHUjelEzc2hZSEVLaFZGdkREdkFFbXlDVFBCM2tSa0haZEQ4UUNieWtBUHBvcGo1bmc0dSIsImFsZyI6IkVTMjU2SyJ9..3zkNi8q9m7bfLoZhMxl-6FluTX16u86jEiro7O_SQJ0ovS0SmX4YRuR7_n7Zn85xF-IhzpM16jMIJj82fz9Tbw"
+      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3Nod0FZTjYzUjRVSGlLc1ZnM2Yzdkc0UmFmTnhBRDRrcEJSMlB4OEpUN2REajEjelEzc2h3QVlONjNSNFVIaUtzVmczZjN2RzRSYWZOeEFENGtwQlIyUHg4SlQ3ZERqMSIsImFsZyI6IkVTMjU2SyJ9..nkYrhJLM6SthFYTQIksv9Xa1El5g9YG0aKsz75uBU8g9iBpfhKu4iQVBNT2nkUE0CilbjkKnYW5QPB-12RHhEA"
     },
     "close": {
       "metadata": {
         "kind": "close",
-        "to": "did:key:zQ3shizeS6VFzTasyXFXcLgYaiLN5yK5PQe9v37VYy9yQzXQq",
-        "from": "did:key:zQ3shYHEKhVFvDDvAEmyCTPB3kRkHZdD8QCbykAPpopj5ng4u",
-        "id": "close_01hd78yfsfe2hr0050mc000034",
-        "exchangeId": "rfq_7zzzzzzfwzf1yr0078fm0012xm",
-        "createdAt": "2023-10-20T19:28:09.994Z"
+        "to": "did:key:zQ3shujqALzHHaiBqC8Fyq9pYudE774t3ub7zc9HtA3GZ8x5S",
+        "from": "did:key:zQ3shwAYN63R4UHiKsVg3f3vG4RafNxAD4kpBR2Px8JT7dDj1",
+        "id": "close_01hdgc6zvzf908006t800009v7",
+        "exchangeId": "rfq_7zzzzzzqvfe1xr007gfc001xkn",
+        "createdAt": "2023-10-24T08:18:18.597Z"
       },
       "data": {
         "reason": "test reason"
       },
-      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3NoWUhFS2hWRnZERHZBRW15Q1RQQjNrUmtIWmREOFFDYnlrQVBwb3BqNW5nNHUjelEzc2hZSEVLaFZGdkREdkFFbXlDVFBCM2tSa0haZEQ4UUNieWtBUHBvcGo1bmc0dSIsImFsZyI6IkVTMjU2SyJ9..zmfbOmR5qEpywemsDFQ4VOqJHtkLYHhFvpexNNVDm880TFik_df24bh8387GSy-U3WeRWEDDYMZ0k0k4KzyViA"
+      "signature": "eyJraWQiOiJkaWQ6a2V5OnpRM3Nod0FZTjYzUjRVSGlLc1ZnM2Yzdkc0UmFmTnhBRDRrcEJSMlB4OEpUN2REajEjelEzc2h3QVlONjNSNFVIaUtzVmczZjN2RzRSYWZOeEFENGtwQlIyUHg4SlQ3ZERqMSIsImFsZyI6IkVTMjU2SyJ9..5lzums4vWjb44UxkcNw2aQPkL9RIT2cN4nNnhhBFLyIHywVGVcbPkWNh3kEKf4DQxwa0oi3zfChggQHCMTkbUg"
     }
   }
 }


### PR DESCRIPTION
## What's Changed
* explicitly set minimum compatible java version to java 17
* add jitpack config file to configure runner to use java 17
* remove redundant version declarations in packages
* fix message and resource digest computations
    * sha-256 hashing the canonicalized json was missing
* `verify` - default `assertionMethods` to an empty list if null