### PR TITLE
Fix signing with ION DIDs

### DIFF
--- a/httpclient/build.gradle.kts
+++ b/httpclient/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.8")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
-  implementation("com.github.TBD54566975:web5-kt:0.0.5-beta")
+  implementation("com.github.TBD54566975:web5-kt:38dfacb6ee")
   implementation("decentralized-identity:did-common-java:1.9.0") // would like to grab this via web5 dids
 
   testImplementation(kotlin("test"))

--- a/protocol/build.gradle.kts
+++ b/protocol/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.8")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-json-org:2.11.0")
-  implementation("com.github.TBD54566975:web5-kt:0.0.5-beta")
+  implementation("com.github.TBD54566975:web5-kt:38dfacb6ee")
   implementation("com.networknt:json-schema-validator:1.0.87")
   implementation("com.nimbusds:nimbus-jose-jwt:9.36")
   implementation("decentralized-identity:did-common-java:1.9.0")

--- a/protocol/src/main/kotlin/tbdex/sdk/protocol/CryptoUtils.kt
+++ b/protocol/src/main/kotlin/tbdex/sdk/protocol/CryptoUtils.kt
@@ -102,7 +102,7 @@ object CryptoUtils {
     val assertionMethod: VerificationMethod = when {
       assertionMethodId != null -> assertionMethods.find { it.id.toString() == assertionMethodId }
       else -> assertionMethods.firstOrNull()
-    } ?: throw SignatureException("assertion method $assertionMethodId not found")
+    } ?: throw SignatureException("Assertion method $assertionMethodId not found")
 
     // TODO: ensure that publicKeyJwk is not null
     val publicKeyJwk = JWK.parse(assertionMethod.publicKeyJwk)
@@ -111,9 +111,13 @@ object CryptoUtils {
     val publicKey = did.keyManager.getPublicKey(keyAlias)
     val algorithm = publicKey.algorithm
     val jwsAlgorithm = JWSAlgorithm.parse(algorithm.toString())
+    val kid = when (assertionMethod.id.isAbsolute) {
+      true -> assertionMethod.id.toString()
+      false -> "${did.uri}${assertionMethod.id}"
+    }
 
     val jwsHeader = JWSHeader.Builder(jwsAlgorithm)
-      .keyID(assertionMethod.id.toString())
+      .keyID(kid)
       .build()
 
     // Create payload

--- a/protocol/src/test/kotlin/tbdex/sdk/protocol/TestData.kt
+++ b/protocol/src/test/kotlin/tbdex/sdk/protocol/TestData.kt
@@ -30,6 +30,7 @@ import web5.sdk.credentials.VcDataModel
 import web5.sdk.credentials.VerifiableCredential
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.dids.Did
+import web5.sdk.dids.DidIonManager
 import web5.sdk.dids.DidKey
 import java.net.URI
 import java.time.OffsetDateTime
@@ -43,6 +44,8 @@ object TestData {
   private val pfiKeyManager = InMemoryKeyManager()
   val ALICE_DID: Did = DidKey.create(aliceKeyManager)
   val PFI_DID: Did = DidKey.create(pfiKeyManager)
+
+  val ION_DID: Did = DidIonManager.create(pfiKeyManager)
 
   fun getPresentationDefinition(): PresentationDefinitionV2 {
     return buildPresentationDefinition(

--- a/protocol/src/test/kotlin/tbdex/sdk/protocol/models/OfferingTest.kt
+++ b/protocol/src/test/kotlin/tbdex/sdk/protocol/models/OfferingTest.kt
@@ -49,4 +49,13 @@ class OfferingTest {
 
     assertDoesNotThrow { Resource.parse(Json.stringify(offering)) }
   }
+
+  @Test
+  fun `can parse an offering sign with ION DID`() {
+    val offering = TestData.getOffering()
+    offering.sign(TestData.ION_DID)
+
+    assertDoesNotThrow { Resource.parse(Json.stringify(offering)) }
+  }
+
 }

--- a/protocol/src/test/kotlin/tbdex/sdk/protocol/models/RfqTest.kt
+++ b/protocol/src/test/kotlin/tbdex/sdk/protocol/models/RfqTest.kt
@@ -44,6 +44,15 @@ class RfqTest {
   }
 
   @Test
+  fun `can parse an RFQ signed with ION DID`() {
+    val rfq = TestData.getRfq()
+    rfq.sign(TestData.ION_DID)
+    val payload = Json.stringify(rfq)
+
+    assertDoesNotThrow { Message.parse(payload) }
+  }
+
+  @Test
   fun `can validate a rfq`() {
     val rfq = TestData.getRfq()
     rfq.sign(TestData.ALICE_DID)


### PR DESCRIPTION
Copy a fix from web5-kt by @andresuribe87.

Fixes error:
> org.opentest4j.AssertionFailedError: Unexpected exception thrown: foundation.identity.did.parser.ParserException: Cannot parse DID URL: #7ea7d423-ee74-4b2d-9b03-6d8f979e378e