### PR TITLE
Version bump

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@
 # The format is described: https://github.blog/2017-07-06-introducing-code-owners/
 
 # These owners will be the default owners for everything in the repo.
-* @mistermoe @phoebe-lew @jiyoontbd @michaelneale @KendallWeihe @ethan-tbd
+* @mistermoe @phoebe-lew @jiyoontbd @michaelneale @KendallWeihe @ethan-tbd @tomdaffurn
 
 # -----------------------------------------------
 # BELOW THIS LINE ARE TEMPLATES, UNUSED

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # tbdex-kt
+[![License](https://img.shields.io/github/license/TBD54566975/web5-kt)](https://github.com/TBD54566975/tbdex-kt/blob/main/LICENSE) [![tbdex SDK Kotlin CI](https://github.com/TBD54566975/tbdex-kt/actions/workflows/ci.yaml/badge.svg)](https://github.com/TBD54566975/tbdex-kt/actions/workflows/ci.yaml)
+
 This repo contains 3 jvm packages:
 
 * [`/protocol`](./protocol/) - create, parse, verify, and validate the tbdex messages and resources defined in the [protocol draft specification](https://github.com/TBD54566975/tbdex/blob/main/README.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # tbdex-kt
-[![License](https://img.shields.io/github/license/TBD54566975/web5-kt)](https://github.com/TBD54566975/tbdex-kt/blob/main/LICENSE) [![tbdex SDK Kotlin CI](https://github.com/TBD54566975/tbdex-kt/actions/workflows/ci.yaml/badge.svg)](https://github.com/TBD54566975/tbdex-kt/actions/workflows/ci.yaml)
+[![License](https://img.shields.io/github/license/TBD54566975/web5-kt)](https://github.com/TBD54566975/tbdex-kt/blob/main/LICENSE) [![CI](https://github.com/TBD54566975/tbdex-kt/actions/workflows/ci.yaml/badge.svg)](https://github.com/TBD54566975/tbdex-kt/actions/workflows/ci.yaml)
 
 This repo contains 3 jvm packages:
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 }
 
 allprojects {
-  version = "0.0.1"
+  version = "0.1.0"
   group = "tbdex"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 }
 
 allprojects {
-  version = "0.0.0"
+  version = "0.0.1"
   group = "tbdex"
 }
 


### PR DESCRIPTION
* Bump version to `0.1.0`
* Add hipster badges. will add [version badge](https://shields.io/badges/jit-pack) once we publish `0.1.0`