### PR TITLE
Fix web5-kt version tag & broken schema links

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 }
 
 allprojects {
-  version = "0.5.0"
+  version = "0.6.0"
   group = "tbdex"
 }
 

--- a/httpclient/build.gradle.kts
+++ b/httpclient/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.8")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
-  implementation("com.github.TBD54566975:web5-kt:0.0.9-beta")
+  implementation("com.github.TBD54566975:web5-kt:v0.0.9-beta")
   implementation("decentralized-identity:did-common-java:1.9.0") // would like to grab this via web5 dids
 
   testImplementation(kotlin("test"))

--- a/protocol/build.gradle.kts
+++ b/protocol/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
   api("de.fxlae:typeid-java-jdk8:0.2.0")
-  api("com.github.TBD54566975:web5-kt:0.0.9-beta")
+  api("com.github.TBD54566975:web5-kt:v0.0.9-beta")
 
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.8")

--- a/protocol/src/main/resources/definitions.json
+++ b/protocol/src/main/resources/definitions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://tbdex.dev/definitions.json",
+  "$id": "https://tbdex.dev/json-schema/definitions.json",
   "type": "object",
   "definitions": {
     "did": {

--- a/protocol/src/main/resources/index.html
+++ b/protocol/src/main/resources/index.html
@@ -14,9 +14,9 @@
   <div>
     <h2>Resources</h2>
     <ul>
-      <li><a class="resource" href="https://tbdex.dev/resource.schema.json" class="href">resource</a></li>
-      <li><a class="resource" href="https://tbdex.dev/offering.schema.json" class="href">offering</a></li>
-      <li><a class="resource" href="https://tbdex.dev/reputation.schema.json" class="href">reputation</a></li>
+      <li><a class="resource" href="https://tbdex.dev/json-schemas/resource.schema.json" class="href">resource</a></li>
+      <li><a class="resource" href="https://tbdex.dev/json-schemas/offering.schema.json" class="href">offering</a></li>
+      <li><a class="resource" href="https://tbdex.dev/json-schemas/reputation.schema.json" class="href">reputation</a></li>
     </ul>
   </div>
 
@@ -35,7 +35,7 @@
   <div>
     <h2>Shared</h2>
     <ul>
-      <li><a class="shared" href="https://tbdex.dev/definitions.json" class="href">definitions</a></li>
+      <li><a class="shared" href="https://tbdex.dev/json-schemas/definitions.json" class="href">definitions</a></li>
     </ul>
   </div>
 </body>

--- a/protocol/src/main/resources/message.schema.json
+++ b/protocol/src/main/resources/message.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://tbdex.dev/message.schema.json",
+  "$id": "https://tbdex.dev/json-schemas/message.schema.json",
   "definitions": {
     "MessageMetadata": {
       "type": "object",
@@ -10,7 +10,7 @@
           "description": "The sender's DID"
         },
         "to": {
-          "$ref": "https://tbdex.dev/definitions.json#/definitions/did",
+          "$ref": "https://tbdex.dev/json-schemas/definitions.json#/definitions/did",
           "description": "The recipient's DID"
         },
         "kind": {

--- a/protocol/src/main/resources/resource.schema.json
+++ b/protocol/src/main/resources/resource.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://tbdex.dev/resource.schema.json",
+  "$id": "https://tbdex.dev/json-schemas/resource.schema.json",
   "type": "object",
   "properties": {
     "metadata": {
       "type": "object",
       "properties": {
         "from": {
-          "$ref": "https://tbdex.dev/definitions.json#/definitions/did",
+          "$ref": "https://tbdex.dev/json-schemas/definitions.json#/definitions/did",
           "description": "The PFI's DID"
         },
         "kind": {


### PR DESCRIPTION
- Latest on main fails to build because of change to `web5-kt`'s package version
- Also, schema URLs changes, which is causing tests to fail