### PR TITLE
Fix httpserver web5 dependency

### DIFF
--- a/httpclient/build.gradle.kts
+++ b/httpclient/build.gradle.kts
@@ -19,13 +19,14 @@ repositories {
 }
 
 dependencies {
+  api("de.fxlae:typeid-java-jdk8:0.2.0")
+  api("xyz.block:web5:0.0.9-delta")
+
   implementation(project(":protocol"))
-  implementation("de.fxlae:typeid-java-jdk8:0.2.0")
   implementation("com.squareup.okhttp3:okhttp:4.9.1")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.8")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
-  implementation("xyz.block:web5:0.0.9-delta")
   implementation("decentralized-identity:did-common-java:1.9.0") // would like to grab this via web5 dids
 
   testImplementation(kotlin("test"))

--- a/httpserver/build.gradle.kts
+++ b/httpserver/build.gradle.kts
@@ -24,13 +24,14 @@ application {
 }
 
 dependencies {
+  api("de.fxlae:typeid-java-jdk8:0.2.0")
+  api("xyz.block:web5:0.0.9-delta")
+
   implementation(project(":protocol"))
   implementation(project(":httpclient"))
-  implementation("de.fxlae:typeid-java-jdk8:0.2.0")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.16.0")
-  implementation("com.github.TBD54566975:web5-kt:v0.0.9-gamma")
   implementation("decentralized-identity:did-common-java:1.9.0") // would like to grab this via web5 dids
   implementation("io.ktor:ktor-server-core")
   implementation("io.ktor:ktor-server-netty")


### PR DESCRIPTION
I'm battling build issues

- `0.7.0-beta` [originally failed](https://jitpack.io/com/github/TBD54566975/tbdex-kt/0.7.0-beta/build.log) 
  - error logs are reporting dependency issue, which is easily fixable (done here in this PR)
  - when I built locally I was getting a different build issue; issue related to the `import` statement fixes from [this PR](https://github.com/TBD54566975/tbdex-kt/pull/116) (cc @diehuxx)
  - that PR was already approved so decided to merge and cut a `0.7.1-beta`
- `0.7.1-beta` [failed again](https://jitpack.io/com/github/TBD54566975/tbdex-kt/0.7.1-beta/build.log), with same issue with respect to web5 dependency
  - from the logs I can see this is the build command: `./gradlew clean -Pgroup=com.github.TBD54566975 -Pversion=0.7.1-beta -xtest assemble publishToMavenLocal`
  - tried to recreate that failure locally, but for whatever reason I can't seem to recreate it
  - somewhere I must have that `0.9.0-delta` web5 JAR cached, but searching for it isn't yielding any results

So anyways, I think this should fix things, but can't confirm b/c can't recreate issue locally

---

I decided to add the following, to both the `httpclient` and `httpserver` (where the current issue is)...

```kotlin
  api("de.fxlae:typeid-java-jdk8:0.2.0")
  api("xyz.block:web5:0.0.9-delta")
```

...such that, it's consistent with what's in `protocol` ([here](https://github.com/TBD54566975/tbdex-kt/blob/1609fa2b4f690b836671b27c201648292a9a6102/protocol/build.gradle.kts#L23)). But, since both `httpclient` and `httpserver` depend on `protocol` and `protocol` exposes those dependencies with the `api()` method, we _could_ just remove them altogether from `httpclient` and `httpserver`. But, that's a slightly different developer experience than what we have now... so idk, I just went with existing patterns.

What do we think? Should we remove those two dependency lines from `httpclient` and `httpserver`?