### PR TITLE
fix submitcallback to use message instead of messagetype

### DIFF
--- a/httpserver/src/main/kotlin/tbdex/sdk/httpserver/handlers/SubmitClose.kt
+++ b/httpserver/src/main/kotlin/tbdex/sdk/httpserver/handlers/SubmitClose.kt
@@ -66,7 +66,7 @@ suspend fun submitClose(
   }
 
   try {
-    callback.invoke(call, MessageKind.close, null)
+    callback.invoke(call, message, null)
   } catch (e: CallbackError) {
     call.respond(e.statusCode, ErrorResponse(e.details))
     return

--- a/httpserver/src/main/kotlin/tbdex/sdk/httpserver/handlers/SubmitOrder.kt
+++ b/httpserver/src/main/kotlin/tbdex/sdk/httpserver/handlers/SubmitOrder.kt
@@ -75,7 +75,7 @@ suspend fun submitOrder(
   }
 
   try {
-    callback.invoke(call, MessageKind.close, null)
+    callback.invoke(call, message, null)
   } catch (e: CallbackError) {
     call.respond(e.statusCode, ErrorResponse(e.details))
     return

--- a/httpserver/src/main/kotlin/tbdex/sdk/httpserver/handlers/SubmitRfq.kt
+++ b/httpserver/src/main/kotlin/tbdex/sdk/httpserver/handlers/SubmitRfq.kt
@@ -73,7 +73,7 @@ suspend fun submitRfq(
   }
 
   try {
-    callback.invoke(call, MessageKind.rfq, offering)
+    callback.invoke(call, message, offering)
   } catch (e: CallbackError) {
     call.respond(e.statusCode, ErrorResponse(e.details))
     return

--- a/httpserver/src/main/kotlin/tbdex/sdk/httpserver/models/Callback.kt
+++ b/httpserver/src/main/kotlin/tbdex/sdk/httpserver/models/Callback.kt
@@ -9,20 +9,20 @@ import tbdex.sdk.protocol.models.Offering
 /**
  * Represents a callback function for handling GET requests with specified filters.
  *
- * @param call The Ktor application call object representing the incoming HTTP request.
- * @param filter The filter used in the GET request.
+ * @param ApplicationCall The Ktor application call object representing the incoming HTTP request.
+ * @param Filter The filter used in the GET request.
  * @return Any result returned from the callback.
  */
-typealias GetCallback = (ApplicationCall, Filter) -> Any
+typealias GetCallback = suspend (ApplicationCall, Filter) -> Any
 
 /**
- * Represents a callback function for handling submit requests with specified message kind and offering.
+ * Represents a callback function for handling submit requests with received message and associated offering.
  *
- * @param call The Ktor application call object representing the incoming HTTP request.
- * @param messageKind The kind of message being submitted (RFQ, order, close, etc.).
- * @param offering The offering associated with the submitted message.
+ * @param ApplicationCall The Ktor application call object representing the incoming HTTP request.
+ * @param Message the message received in the request to be processed further by the callback function
+ * @param Offering The offering associated with the submitted message.
  */
-typealias SubmitCallback = (ApplicationCall, Message, Offering?) -> Unit
+typealias SubmitCallback = suspend (ApplicationCall, Message, Offering?) -> Unit
 
 /**
  * Enum representing the kinds of messages that can be submitted.

--- a/httpserver/src/main/kotlin/tbdex/sdk/httpserver/models/Callback.kt
+++ b/httpserver/src/main/kotlin/tbdex/sdk/httpserver/models/Callback.kt
@@ -3,7 +3,7 @@ package tbdex.sdk.httpserver.models
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import tbdex.sdk.httpclient.models.ErrorDetail
-import tbdex.sdk.protocol.models.MessageKind
+import tbdex.sdk.protocol.models.Message
 import tbdex.sdk.protocol.models.Offering
 
 /**
@@ -22,7 +22,7 @@ typealias GetCallback = (ApplicationCall, Filter) -> Any
  * @param messageKind The kind of message being submitted (RFQ, order, close, etc.).
  * @param offering The offering associated with the submitted message.
  */
-typealias SubmitCallback = (ApplicationCall, MessageKind, Offering?) -> Unit
+typealias SubmitCallback = (ApplicationCall, Message, Offering?) -> Unit
 
 /**
  * Enum representing the kinds of messages that can be submitted.


### PR DESCRIPTION
Replace usage of `MessageKind` with `Message` in the `SubmitCallback` definition as well as where it is used 