### PR TITLE
Extracts Publish Tests Report Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,19 +7,19 @@ on:
       - main
   pull_request:
     branches:
-      - '*'
+      - "*"
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ubuntu-latest]
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
         with:
-          submodules: 'true'
+          submodules: "true"
       - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v1
         with:
@@ -39,48 +39,17 @@ jobs:
           verbose: true
           flags: ${{ runner.os }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: test-results
           path: |
             **/build/test-results/test/*TbdexTestVectors*.xml
 
-      - name: Publish Tests Results
-        env:
-          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
-        run: |
-          declare -a projects=("protocol" "httpclient")
-          
-          for project in "${projects[@]}"; do
-            # Find Tests Reports in each project and store them in an array
-            files=($(find "${project}/build/test-results/test" -name '*.xml'))
-          
-            # Check if files array is empty
-            if [ ${#files[@]} -eq 0 ]; then
-              echo "No Tests files found in ${project} directory!"
-              exit 1
-            else
-              echo "Found ${#files[@]} XML files in ${project} directory, proceeding with upload..."
-            fi
-          
-            # Iterate over the files and upload each one
-            for file in "${files[@]}"; do
-                echo "Uploading ${file} to BuildKite..."
-                curl \
-                  -X POST \
-                  --fail-with-body \
-                  -H "Authorization: Token token=\"$BUILDKITE_ANALYTICS_TOKEN\"" \
-                  -F "data=@$file" \
-                  -F "format=junit" \
-                  -F "run_env[CI]=github_actions" \
-                  -F "run_env[key]=$GITHUB_ACTION-$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT" \
-                  -F "run_env[number]=$GITHUB_RUN_NUMBER" \
-                  -F "run_env[branch]=$GITHUB_REF" \
-                  -F "run_env[commit_sha]=$GITHUB_SHA" \
-                  -F "run_env[url]=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-                  https://analytics-api.buildkite.com/v1/uploads
-            done
-          done
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: tests-report-junit
+          path: |
+            **/build/test-results/test/*.xml
 
       - name: Generate an access token to trigger downstream repo
         uses: actions/create-github-app-token@2986852ad836768dfea7781f31828eb3e17990fa # v1.6.2

--- a/.github/workflows/tests-publish.yml
+++ b/.github/workflows/tests-publish.yml
@@ -1,0 +1,57 @@
+name: Publish Tests Report
+
+on:
+  workflow_run:
+    workflows: ["tbdex SDK Kotlin CI"]
+    types:
+      - completed
+
+jobs:
+  comment-action:
+    name: Publish Tests Report
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download TBDocs Report
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          name: tests-report-junit
+          path: ./
+
+      - name: Publish Tests Report
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
+        run: |
+          declare -a projects=("protocol" "httpclient")
+
+          for project in "${projects[@]}"; do
+            # Find Tests Reports in each project and store them in an array
+            files=($(find "${project}/build/test-results/test" -name '*.xml'))
+
+            # Check if files array is empty
+            if [ ${#files[@]} -eq 0 ]; then
+              echo "No Tests files found in ${project} directory!"
+              exit 1
+            else
+              echo "Found ${#files[@]} XML files in ${project} directory, proceeding with upload..."
+            fi
+
+            # Iterate over the files and upload each one
+            for file in "${files[@]}"; do
+                echo "Uploading ${file} to BuildKite..."
+                curl \
+                  -X POST \
+                  --fail-with-body \
+                  -H "Authorization: Token token=\"$BUILDKITE_ANALYTICS_TOKEN\"" \
+                  -F "data=@$file" \
+                  -F "format=junit" \
+                  -F "run_env[CI]=github_actions" \
+                  -F "run_env[key]=$GITHUB_ACTION-$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT" \
+                  -F "run_env[number]=$GITHUB_RUN_NUMBER" \
+                  -F "run_env[branch]=$GITHUB_REF" \
+                  -F "run_env[commit_sha]=$GITHUB_SHA" \
+                  -F "run_env[url]=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+                  https://analytics-api.buildkite.com/v1/uploads
+            done
+          done

--- a/.github/workflows/tests-publish.yml
+++ b/.github/workflows/tests-publish.yml
@@ -1,15 +1,6 @@
 name: Publish Tests Report
 
 on:
-  workflow_dispatch:
-    # allow to input a custom run_id
-    inputs:
-      run_id:
-        description: "The run_id of the workflow run to download artifacts from"
-        required: true
-  pull_request: # todo: remove
-    branches:
-      - "*"
   workflow_run:
     workflows: ["tbdex SDK Kotlin CI"]
     types:

--- a/.github/workflows/tests-publish.yml
+++ b/.github/workflows/tests-publish.yml
@@ -15,9 +15,7 @@ jobs:
       - name: Download TBDocs Report
         uses: dawidd6/action-download-artifact@v2
         with:
-          # manual input or from the workflow_run event
-          run_id: ${{ github.event.inputs.run_id || github.event.workflow_run.id }}
-          # run_id: ${{ github.event.workflow_run.id }}
+          run_id: ${{ github.event.workflow_run.id }}
           name: tests-report-junit
           path: ./
 

--- a/.github/workflows/tests-publish.yml
+++ b/.github/workflows/tests-publish.yml
@@ -1,6 +1,12 @@
 name: Publish Tests Report
 
 on:
+  workflow_dispatch:
+    # allow to input a custom run_id
+    inputs:
+      run_id:
+        description: "The run_id of the workflow run to download artifacts from"
+        required: true
   workflow_run:
     workflows: ["tbdex SDK Kotlin CI"]
     types:
@@ -15,7 +21,9 @@ jobs:
       - name: Download TBDocs Report
         uses: dawidd6/action-download-artifact@v2
         with:
-          run_id: ${{ github.event.workflow_run.id }}
+          # manual input or from the workflow_run event
+          run_id: ${{ github.event.inputs.run_id || github.event.workflow_run.id }}
+          # run_id: ${{ github.event.workflow_run.id }}
           name: tests-report-junit
           path: ./
 

--- a/.github/workflows/tests-publish.yml
+++ b/.github/workflows/tests-publish.yml
@@ -7,6 +7,9 @@ on:
       run_id:
         description: "The run_id of the workflow run to download artifacts from"
         required: true
+  pull_request: # todo: remove
+    branches:
+      - "*"
   workflow_run:
     workflows: ["tbdex SDK Kotlin CI"]
     types:

--- a/.github/workflows/tests-publish.yml
+++ b/.github/workflows/tests-publish.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Publish Tests Report
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           declare -a projects=("protocol" "httpclient")
 
@@ -51,7 +52,7 @@ jobs:
                   -F "run_env[number]=$GITHUB_RUN_NUMBER" \
                   -F "run_env[branch]=$GITHUB_REF" \
                   -F "run_env[commit_sha]=$GITHUB_SHA" \
-                  -F "run_env[url]=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+                  -F "run_env[url]=https://github.com/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_ID" \
                   https://analytics-api.buildkite.com/v1/uploads
             done
           done


### PR DESCRIPTION
To prevent build issues on fork PRs when uploading the tests report to BuildKite.

Also, as an overall improvement since this upload should not be cause to fail a CI build.
(as discussed here: https://discord.com/channels/937858703112155166/1203077812269875251)