### PR TITLE
Align versioning across tbDEX subprojects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,14 +6,15 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.net.URL
 
 plugins {
-  id("org.jetbrains.kotlin.jvm") version "1.9.0"
-  id("java-library")
+  id("org.jetbrains.kotlin.jvm") version "1.9.22"
+  id("base")
   id("io.gitlab.arturbosch.detekt") version "1.23.1"
   `maven-publish`
   id("org.jetbrains.dokka") version "1.9.0"
   id("org.jetbrains.kotlinx.kover") version "0.7.3"
   signing
   id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
+  id("version-catalog")
 }
 
 repositories {
@@ -43,6 +44,7 @@ subprojects {
     plugin("org.jetbrains.dokka")
     plugin("org.jetbrains.kotlinx.kover")
     plugin("signing")
+    plugin("version-catalog")
   }
 
   tasks.withType<Detekt>().configureEach {
@@ -78,7 +80,7 @@ subprojects {
       create<MavenPublication>(publicationName) {
         groupId = project.group.toString()
         artifactId = name
-        description = "Kotlin SDK for tbdex functionality"
+        description = name
         version = project.property("version").toString()
         from(components["java"])
       }
@@ -87,7 +89,7 @@ subprojects {
         pom {
           name = publicationName
           packaging = "jar"
-          description.set("tbdex kotlin SDK")
+          description.set("tbDEX SDK for the JVM")
           url.set("https://github.com/TBD54566975/tbdex-kt")
           inceptionYear.set("2023")
           licenses {
@@ -167,14 +169,14 @@ publishing {
     create<MavenPublication>(rootProject.name) {
       groupId = project.group.toString()
       artifactId = name
-      description = "Kotlin SDK for tbdex functionality"
+      description = name
       version = project.property("version").toString()
       from(components["java"])
 
       pom {
-        packaging = "jar"
-        name = project.name
-        description.set("tbdex kotlin SDK")
+        packaging = "pom"
+        name = "tbDEX SDK for the JVM"
+        description.set("tbDEX SDK for the JVM")
         url.set("https://github.com/TBD54566975/tbdex-kt")
         inceptionYear.set("2023")
         licenses {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,51 @@
+###
+# This section is where we declare the versioning and scope for dependencies of
+# the tbDEX platform and projects building atop the tbDEX platform.
+#
+# Submodules of tbDEX are not able to define their own dependency versions
+# because these must all co-exist in the same ClassLoading environment, and
+# therefore have to be aligned across submodules. Thus we declare the versioning
+# requirements here at the platform level.
+#
+# Additionally, dependencies shared with Web5 must be version aligned because tbDEX
+# is built atop Web5 and these two platforms must co-exist in the same ClassLoading
+# environment as well. Default to versions already defined in Web5 if present, and do
+# not override here.
+#
+# If a submodule needs to introduce a new dependency or upgrade, define that
+# dependency and version here such that other submodules in the build may pick
+# up the same version. This will guarantee that submodule test suites are running
+# in the correct ClassLoading environment aligned throughout the tbDEX and Web5 platforms.
+#
+# More about Gradle Version Catalogs:
+# https://docs.gradle.org/current/userguide/platforms.html
+#
+# Helpful Blog:
+# https://umang91.medium.com/version-catalogs-in-gradle-7-0-816873b59b47
+###
+
+[versions]
+com_fasterxml_jackson = "2.14.2"
+com_networknt = "1.0.87"
+com_squareup_okhttp = "4.12.0"
+de_fxlae = "0.2.0"
+io_ktor = "2.3.7"
+xyz_block_web5 = "0.11.0"
+
+[libraries]
+comFasterXmlJacksonModuleKotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "com_fasterxml_jackson" }
+comFasterXmlJacksonDatatypeJsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "com_fasterxml_jackson" }
+comNetworkntJsonSchemaValidator = { module = "com.networknt:json-schema-validator", version.ref = "com_networknt" }
+comSquareupOkhttpOkhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "com_squareup_okhttp" }
+comSquareupOkhttpMockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "com_squareup_okhttp" }
+deFxlaeTypeId = { module = "de.fxlae:typeid-java-jdk8", version.ref = "de_fxlae" }
+ioKtorClientAuth = { module = "io.ktor:ktor-client-auth", version.ref = "io_ktor" }
+ioKtorSerializationJackson = { module = "io.ktor:ktor-serialization-jackson", version.ref = "io_ktor" }
+ioKtorServerContentNegotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "io_ktor" }
+ioKtorServerNetty = { module = "io.ktor:ktor-server-netty", version.ref = "io_ktor" }
+xyzBlockWeb5 = { module = "xyz.block:web5", version.ref = "xyz_block_web5" }
+
+[bundles]
+testBundleName = [
+  "xyzBlockWeb5"
+]

--- a/httpclient/build.gradle.kts
+++ b/httpclient/build.gradle.kts
@@ -29,18 +29,40 @@ repositories {
 val jackson_version = "2.14.2"
 
 dependencies {
-  api("de.fxlae:typeid-java-jdk8:0.2.0")
-  api("xyz.block:web5:0.0.11")
 
+  /**
+   * Maintainers - please do not declare versioning here at the module level;
+   * dependencies are either pulled in transitively via web5-kt, or
+   * centralized for the platform in $projectRoot/gradle/libs.versions.toml
+   *
+   * Deps are declared in alphabetical order.
+   */
+
+  // API
+  api(libs.xyzBlockWeb5)
+
+  /*
+   * API Leak: https://github.com/TBD54566975/tbdex-kt/issues/161
+   *
+   * Change and move to "implementation" when completed
+   */
+  api(libs.deFxlaeTypeId)
+
+  // Project
   implementation(project(":protocol"))
-  implementation("com.squareup.okhttp3:okhttp:4.9.1")
-  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
-  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version")
-  implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_version")
-  implementation("decentralized-identity:did-common-java:1.9.0") // would like to grab this via web5 dids
 
+  // Implementation
+  implementation(libs.comSquareupOkhttpOkhttp)
+  implementation(libs.comFasterXmlJacksonModuleKotlin)
+
+  // Test
+  /**
+   * Test dependencies may declare direct versions; they are not exported
+   * and therefore are within the remit of this module to self-define
+   * if desired.
+   */
   testImplementation(kotlin("test"))
-  testImplementation("com.squareup.okhttp3:mockwebserver:4.11.0")
+  testImplementation(libs.comSquareupOkhttpMockwebserver)
   testImplementation("com.willowtreeapps.assertk:assertk:0.27.0")
   testImplementation("io.mockk:mockk:1.13.9")
 

--- a/httpserver/build.gradle.kts
+++ b/httpserver/build.gradle.kts
@@ -30,24 +30,44 @@ repositories {
 application {
   mainClass.set("tbdex.sdk.httpserver.TbdexHttpServerKt")
 }
-val jackson_version = "2.14.2"
 
 dependencies {
-  api("de.fxlae:typeid-java-jdk8:0.2.0")
-  api("xyz.block:web5:0.0.11")
 
+  /**
+   * Maintainers - please do not declare versioning here at the module level;
+   * dependencies are either pulled in transitively via web5-kt, or
+   * centralized for the platform in $projectRoot/gradle/libs.versions.toml
+   *
+   * Deps are declared in alphabetical order.
+   */
+
+  // API
+  api(libs.xyzBlockWeb5)
+
+  /*
+   * API Leak: https://github.com/TBD54566975/tbdex-kt/issues/161
+   *
+   * Change and move to "implementation" when completed
+   */
+  api(libs.deFxlaeTypeId)
+
+  // Project
   implementation(project(":protocol"))
   implementation(project(":httpclient"))
-  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
-  implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_version")
-  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version")
-  implementation("decentralized-identity:did-common-java:1.9.0") // would like to grab this via web5 dids
-  implementation("io.ktor:ktor-server-core")
-  implementation("io.ktor:ktor-server-netty")
-  implementation("io.ktor:ktor-server-content-negotiation")
-  implementation("io.ktor:ktor-serialization-jackson")
-  implementation("io.ktor:ktor-client-auth:2.3.7")
 
+  // Implementation
+  implementation(libs.comFasterXmlJacksonDatatypeJsr310)
+  implementation(libs.ioKtorClientAuth)
+  implementation(libs.ioKtorSerializationJackson)
+  implementation(libs.ioKtorServerContentNegotiation)
+  implementation(libs.ioKtorServerNetty)
+
+  // Test
+  /**
+   * Test dependencies may declare direct versions; they are not exported
+   * and therefore are within the remit of this module to self-define
+   * if desired.
+   */
   testImplementation(kotlin("test"))
   testImplementation("com.willowtreeapps.assertk:assertk:0.27.0")
   testImplementation("io.ktor:ktor-server-test-host")

--- a/protocol/build.gradle.kts
+++ b/protocol/build.gradle.kts
@@ -26,19 +26,38 @@ repositories {
   }
 }
 
-val jackson_version = "2.14.2"
-
 dependencies {
-  api("de.fxlae:typeid-java-jdk8:0.2.0")
-  api("xyz.block:web5:0.0.11")
 
-  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
-  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version")
-  implementation("com.fasterxml.jackson.datatype:jackson-datatype-json-org:$jackson_version")
-  implementation("com.networknt:json-schema-validator:1.0.87")
-  implementation("com.nimbusds:nimbus-jose-jwt:9.36")
-  implementation("decentralized-identity:did-common-java:1.9.0")
-  implementation("io.github.erdtman:java-json-canonicalization:1.1")
+  /**
+   * Maintainers - please do not declare versioning here at the module level;
+   * dependencies are either pulled in transitively via web5-kt, or
+   * centralized for the platform in $projectRoot/gradle/libs.versions.toml
+   *
+   * Deps are declared in alphabetical order.
+   */
+
+  // API
+  api(libs.xyzBlockWeb5)
+  /*
+   * API Leak: https://github.com/TBD54566975/tbdex-kt/issues/161
+   *
+   * Change and move to "implementation" when completed
+   */
+  api(libs.deFxlaeTypeId)
+
+  // Project
+
+  // Implementation
+  implementation(libs.comFasterXmlJacksonModuleKotlin)
+  implementation(libs.comFasterXmlJacksonDatatypeJsr310)
+  implementation(libs.comNetworkntJsonSchemaValidator)
+
+  // Test
+  /**
+   * Test dependencies may declare direct versions; they are not exported
+   * and therefore are within the remit of this module to self-define
+   * if desired.
+   */
   testImplementation(kotlin("test"))
   testImplementation("com.willowtreeapps.assertk:assertk:0.27.0")
 }


### PR DESCRIPTION
Fulfills #159.

* Remove Web5 transitive deps
* Introduce Version Catalog for tbDEX deps
* Document and link to issues for API leaks
* Updates `tbdex-kt` to `web5-kt:0.11.0`  

What this does not do:

* Align versions with Web5. Must work incrementally and follow up with that.

Dependency:

* https://github.com/TBD54566975/web5-kt/issues/226