### PR TITLE
Suite of Security Vulnerability Fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,8 @@ allprojects {
       force("com.fasterxml.woodstox:woodstox-core:6.4.0")
       // Addresss https://github.com/TBD54566975/tbdex-kt/issues/168
       force("com.google.guava:guava:32.0.0-android")
+      // Addresss https://github.com/TBD54566975/tbdex-kt/issues/169
+      force("com.google.protobuf:protobuf-javalite:3.19.6")
     }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,35 @@ dependencies {
 }
 
 allprojects {
+
   group = "xyz.block"
+
+  configurations.all {
+    /**
+     * In this section we address build issues including security vulnerabilities
+     * in transitive dependencies we don't explicitly declare in
+     * `gradle/libs.versions.toml`. Forced actions taken here will override any
+     * declarations we make, so use with care. Also note: these are in place for a
+     * point in time. As we maintain this software, the manual forced resolution we do
+     * here may:
+     *
+     * 1) No longer be necessary (if we have removed a dependency path leading to dep)
+     * 2) Break an upgrade (if we upgrade a dependency and this forces a lower version
+     *    of a transitive dependency it brings in)
+     *
+     * So we need to exercise care here, and, when upgrading our deps, check to see if
+     * these forces aren't breaking things.
+     *
+     * When adding forces here, please reference the issue which explains why we
+     * needed to do this; it will help future maintainers understand if the force
+     * is still valid, should be removed, or handled in another way.
+     *
+     * When in doubt, ask! :)
+     */
+    resolutionStrategy {
+
+    }
+  }
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,19 @@ dependencies {
   detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.1")
 }
 
+/**
+ * Dependency forcing for build dependencies; see docs below on this
+ * in the "allprojects" block for explanation why this is necessary.
+ */
+buildscript {
+  configurations.all {
+    resolutionStrategy {
+      // Addresss https://github.com/TBD54566975/tbdex-kt/issues/167
+      force("com.fasterxml.woodstox:woodstox-core:6.4.0")
+    }
+  }
+}
+
 allprojects {
 
   group = "xyz.block"
@@ -55,7 +68,8 @@ allprojects {
      * When in doubt, ask! :)
      */
     resolutionStrategy {
-
+      // Addresss https://github.com/TBD54566975/tbdex-kt/issues/167
+      force("com.fasterxml.woodstox:woodstox-core:6.4.0")
     }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,8 @@ allprojects {
       force("com.google.guava:guava:32.0.0-android")
       // Addresss https://github.com/TBD54566975/tbdex-kt/issues/169
       force("com.google.protobuf:protobuf-javalite:3.19.6")
+      // Addresses https://github.com/TBD54566975/tbdex-kt/issues/170
+      force("com.squareup.okio:okio:3.6.0")
     }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,12 @@ dependencies {
 }
 
 /**
- * Dependency forcing for build dependencies; see docs below on this
- * in the "allprojects" block for explanation why this is necessary.
+ * Dependency forcing for build dependencies; this is separate from the code
+ * dependencies below in the "allprojects" block because it concerns the
+ * build itself.
+ *
+ * "allprojects" block below has documentation detailing why forced resolution
+ * strategies are necessary.
  */
 buildscript {
   configurations.all {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,8 @@ allprojects {
     resolutionStrategy {
       // Addresss https://github.com/TBD54566975/tbdex-kt/issues/167
       force("com.fasterxml.woodstox:woodstox-core:6.4.0")
+      // Addresss https://github.com/TBD54566975/tbdex-kt/issues/168
+      force("com.google.guava:guava:32.0.0-android")
     }
   }
 }


### PR DESCRIPTION
NOTE: To preserve version history for these fixes independently, this PR should be rebased, not squashed, on `main` when merging.

From FOSSA, we see `11` security vulnerabilities in `main`: https://github.com/TBD54566975/tbdex-kt/actions/runs/7937580619/job/21675028471#step:4:34

<img width="560" alt="image" src="https://github.com/TBD54566975/tbdex-kt/assets/199891/f3a5e267-dd1b-4f6a-bf14-de864f17dbee">

This PR turns those to `0`:

<img width="958" alt="image" src="https://github.com/TBD54566975/tbdex-kt/assets/199891/8b351ffe-adb7-45e1-8405-39c7740f7c08">

Satisfies:
* #166 
* #167 
* #168
* #169
* #170