### PR TITLE
Overload TbdexHttpClient.getExchange to accept TypeId

### DIFF
--- a/httpclient/src/main/kotlin/tbdex/sdk/httpclient/TbdexHttpClient.kt
+++ b/httpclient/src/main/kotlin/tbdex/sdk/httpclient/TbdexHttpClient.kt
@@ -1,6 +1,7 @@
 package tbdex.sdk.httpclient
 
 import com.fasterxml.jackson.module.kotlin.convertValue
+import de.fxlae.typeid.TypeId
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -98,6 +99,19 @@ object TbdexHttpClient {
     if (!response.isSuccessful) {
       throw buildResponseException(response)
     }
+  }
+
+  /**
+   * Fetches a specific exchange identified by its ID from the PFI.
+   *
+   * @param pfiDid The decentralized identifier of the PFI.
+   * @param requesterDid The decentralized identifier of the entity requesting the exchange.
+   * @param exchangeId The unique identifier of the exchange to be fetched.
+   * @return An [Exchange] containing the requested exchange.
+   * @throws TbdexResponseException for request or response errors.
+   */
+  fun getExchange(pfiDid: String, requesterDid: Did, exchangeId: TypeId): Exchange {
+    return this.getExchange(pfiDid, requesterDid, exchangeId.toString())
   }
 
   /**

--- a/httpclient/src/test/kotlin/tbdex/sdk/httpclient/TbdexHttpClientTest.kt
+++ b/httpclient/src/test/kotlin/tbdex/sdk/httpclient/TbdexHttpClientTest.kt
@@ -118,6 +118,18 @@ class TbdexHttpClientTest {
   }
 
   @Test
+  fun `get exchange TypeId overload success via mockwebserver`() {
+    val offeringId = TypeId.generate("offering")
+    val exchange = listOf(rfq(offeringId), quote())
+    val mockResponseString = Json.jsonMapper.writeValueAsString(mapOf("data" to exchange))
+    server.enqueue(MockResponse().setBody(mockResponseString).setResponseCode(HttpURLConnection.HTTP_OK))
+
+    val response = TbdexHttpClient.getExchange(pfiDid.uri, alice, TypeId.generate("rfq"))
+
+    assertEquals(offeringId, (response[0] as Rfq).data.offeringId)
+  }
+
+  @Test
   fun `get exchange success via mockwebserver`() {
     val offeringId = TypeId.generate("offering")
     val exchange = listOf(rfq(offeringId), quote())


### PR DESCRIPTION
Addresses #171 by allowing `TbdexHttpClient.getExchange()` to take either String or TypeId