### PR TITLE
Fix and test that rfq is wrapped in object in CreateExchange endpoint

### DIFF
--- a/httpclient/src/main/kotlin/tbdex/sdk/httpclient/TbdexHttpClient.kt
+++ b/httpclient/src/main/kotlin/tbdex/sdk/httpclient/TbdexHttpClient.kt
@@ -86,13 +86,16 @@ object TbdexHttpClient {
     val kind = message.metadata.kind
 
     val pfiServiceEndpoint = getPfiServiceEndpoint(pfiDid)
-    val url: String = if (kind == MessageKind.rfq) {
-      "$pfiServiceEndpoint/exchanges/$exchangeId"
-    } else {
-      "$pfiServiceEndpoint/exchanges/$exchangeId/$kind"
-    }
 
-    val body: RequestBody = Json.stringify(message).toRequestBody(jsonMediaType)
+    val body: RequestBody
+    val url: String
+    if (kind == MessageKind.rfq) {
+      body = Json.stringify(CreateExchangeRequest(message as Rfq)).toRequestBody(jsonMediaType)
+      url = "$pfiServiceEndpoint/exchanges/$exchangeId"
+    } else {
+      body = Json.stringify(message).toRequestBody(jsonMediaType)
+      url = "$pfiServiceEndpoint/exchanges/$exchangeId/$kind"
+    }
 
     val request = buildRequest(url, body)
 

--- a/httpclient/src/test/kotlin/tbdex/sdk/httpclient/TbdexHttpClientTest.kt
+++ b/httpclient/src/test/kotlin/tbdex/sdk/httpclient/TbdexHttpClientTest.kt
@@ -96,7 +96,10 @@ class TbdexHttpClientTest {
 
     val request1 = server.takeRequest()
     assertEquals(request1.path, "/exchanges/${rfq.metadata.exchangeId}")
-    assertEquals(request1.body.readUtf8(), Json.stringify(mapOf("rfq" to rfq)))
+    assertEquals(
+      Json.jsonMapper.readTree(request1.body.readUtf8()),
+      Json.jsonMapper.readTree(Json.stringify(mapOf("rfq" to rfq)))
+    )
   }
 
   @Test

--- a/httpclient/src/test/kotlin/tbdex/sdk/httpclient/TbdexHttpClientTest.kt
+++ b/httpclient/src/test/kotlin/tbdex/sdk/httpclient/TbdexHttpClientTest.kt
@@ -2,12 +2,15 @@ package tbdex.sdk.httpclient
 
 import de.fxlae.typeid.TypeId
 import junit.framework.TestCase.assertEquals
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import tbdex.sdk.httpclient.models.CreateExchangeRequest
 import tbdex.sdk.httpclient.models.ErrorDetail
 import tbdex.sdk.httpclient.models.TbdexResponseException
 import tbdex.sdk.protocol.models.Quote
@@ -84,7 +87,20 @@ class TbdexHttpClientTest {
   }
 
   @Test
-  fun `send RFQ success via mockwebserver`() {
+  fun `send RFQ without replyTo success via mockwebserver`() {
+
+    server.enqueue(MockResponse().setResponseCode(HttpURLConnection.HTTP_ACCEPTED))
+
+    val rfq = TestData.getRfq(pfiDid.uri, TypeId.generate("offering"))
+    assertDoesNotThrow { TbdexHttpClient.sendMessage(rfq) }
+
+    val request1 = server.takeRequest()
+    assertEquals(request1.path, "/exchanges/${rfq.metadata.exchangeId}")
+    assertEquals(request1.body.readUtf8(), Json.stringify(mapOf("rfq" to rfq)))
+  }
+
+  @Test
+  fun `send RFQ with replyTo success via mockwebserver`() {
 
     server.enqueue(MockResponse().setResponseCode(HttpURLConnection.HTTP_ACCEPTED))
 


### PR DESCRIPTION
Fixes a bug in implementation of https://github.com/TBD54566975/tbdex/issues/167

Also adds test conditions as per https://github.com/TBD54566975/tbdex-kt/issues/176