### PR TITLE
pulling in latest test vector update from tbdex

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ com_networknt = "1.0.87"
 com_squareup_okhttp = "4.12.0"
 de_fxlae = "0.2.0"
 io_ktor = "2.3.7"
-xyz_block_web5 = "0.11.0"
+xyz_block_web5 = "0.12.0"
 
 [libraries]
 comFasterXmlJacksonModuleKotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "com_fasterxml_jackson" }

--- a/protocol/src/main/kotlin/tbdex/sdk/protocol/CryptoUtils.kt
+++ b/protocol/src/main/kotlin/tbdex/sdk/protocol/CryptoUtils.kt
@@ -107,8 +107,7 @@ object CryptoUtils {
     Crypto.verify(
       publicKey = publicKeyJwk,
       signedPayload = jws.signingInput,
-      signature = jws.signature.decode(),
-      algorithm = jws.header.algorithm
+      signature = jws.signature.decode()
     )
   }
 


### PR DESCRIPTION
also bumps web5-kt version so it includes fixes for kt did:dht resolution per https://github.com/TBD54566975/web5-kt/pull/251