### PR TITLE
Automate GH Release Publication

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,3 +40,13 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEUSERNAME }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        # skips snapshot releases
+        if: contains(github.event.inputs.version, 'SNAPSHOT') == false 
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          draft: false
+          prerelease: true
+          generate_release_notes: true


### PR DESCRIPTION
When a new publish workflow is triggered, and is not a SNAPSHOT, it automatically create the GH release. 

Addresses #98 