### PR TITLE
Use PUT for /exchanges/:exchangeId in client

### DIFF
--- a/httpclient/src/main/kotlin/tbdex/sdk/httpclient/TbdexHttpClient.kt
+++ b/httpclient/src/main/kotlin/tbdex/sdk/httpclient/TbdexHttpClient.kt
@@ -171,7 +171,7 @@ object TbdexHttpClient {
     val request = Request.Builder()
       .url(url)
       .addHeader("Content-Type", JSON_HEADER)
-      .post(requestBody)
+      .put(requestBody)
       .build()
 
     println("Attempting to send message to exchange ${exchangeId} to: ${request.url}")

--- a/httpclient/src/test/kotlin/tbdex/sdk/httpclient/TbdexHttpClientTest.kt
+++ b/httpclient/src/test/kotlin/tbdex/sdk/httpclient/TbdexHttpClientTest.kt
@@ -95,6 +95,7 @@ class TbdexHttpClientTest {
     assertDoesNotThrow { TbdexHttpClient.createExchange(rfq) }
 
     val request = server.takeRequest()
+    assertEquals(request.method, "POST")
     assertEquals(request.path, "/exchanges")
     assertEquals(
       Json.jsonMapper.readTree(request.body.readUtf8()),
@@ -111,6 +112,7 @@ class TbdexHttpClientTest {
     assertDoesNotThrow { TbdexHttpClient.createExchange(rfq, replyTo) }
 
     val request = server.takeRequest()
+    assertEquals(request.method, "POST")
     assertEquals(request.path, "/exchanges")
     assertEquals(
       Json.jsonMapper.readTree(request.body.readUtf8()),
@@ -195,6 +197,7 @@ class TbdexHttpClientTest {
     assertDoesNotThrow { TbdexHttpClient.submitOrder(order) }
 
     val request = server.takeRequest()
+    assertEquals(request.method, "PUT")
     assertEquals(request.path, "/exchanges/${order.metadata.exchangeId}")
     assertEquals(
       Json.jsonMapper.readTree(request.body.readUtf8()),
@@ -253,6 +256,7 @@ class TbdexHttpClientTest {
     assertDoesNotThrow { TbdexHttpClient.submitClose(close) }
 
     val request = server.takeRequest()
+    assertEquals(request.method, "PUT")
     assertEquals(request.path, "/exchanges/${close.metadata.exchangeId}")
     assertEquals(
       Json.jsonMapper.readTree(request.body.readUtf8()),


### PR DESCRIPTION
Thanks @jiyoontbd for flagging !

For the `/exchanges/:exchangeId` endpoint, we should be using PUT, not POST. [Source](https://github.com/TBD54566975/tbdex/issues/225#issuecomment-1986057713)