### PR TITLE
Fix latest releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -45,5 +45,5 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.version }}
           draft: false
-          prerelease: true
+          prerelease: false
           generate_release_notes: true


### PR DESCRIPTION
The new releases are not being updated as latest because of the `prerelease` tag. This PR fixes it. 