### PR TITLE
Create message-kind-specific parse methods and remove circular dependency

### DIFF
--- a/httpclient/src/main/kotlin/tbdex/sdk/httpclient/TbdexHttpClient.kt
+++ b/httpclient/src/main/kotlin/tbdex/sdk/httpclient/TbdexHttpClient.kt
@@ -14,6 +14,7 @@ import tbdex.sdk.httpclient.models.Exchange
 import tbdex.sdk.httpclient.models.GetExchangesFilter
 import tbdex.sdk.httpclient.models.GetOfferingsFilter
 import tbdex.sdk.httpclient.models.TbdexResponseException
+import tbdex.sdk.protocol.Parser
 import tbdex.sdk.protocol.Validator
 import tbdex.sdk.protocol.models.Balance
 import tbdex.sdk.protocol.models.Close
@@ -275,7 +276,7 @@ object TbdexHttpClient {
         val responseString = response.body?.string()
         val jsonNode = jsonMapper.readTree(responseString)
         return jsonNode.get("data").elements().asSequence()
-          .map { Message.parse(it.toString()) }
+          .map { Parser.parseMessage(it.toString()) }
           .toList()
       }
 
@@ -319,7 +320,7 @@ object TbdexHttpClient {
 
         jsonNode.get("data").elements().forEach { jsonExchange ->
           val exchange = jsonExchange.elements().asSequence()
-            .map { Message.parse(it.toString()) }
+            .map { Parser.parseMessage(it.toString()) }
             .toList()
           exchanges.add(exchange)
         }

--- a/httpserver/src/main/kotlin/tbdex/sdk/httpserver/handlers/CreateExchange.kt
+++ b/httpserver/src/main/kotlin/tbdex/sdk/httpserver/handlers/CreateExchange.kt
@@ -10,6 +10,7 @@ import tbdex.sdk.httpserver.models.CreateExchangeCallback
 import tbdex.sdk.httpserver.models.ErrorResponse
 import tbdex.sdk.httpserver.models.ExchangesApi
 import tbdex.sdk.httpserver.models.OfferingsApi
+import tbdex.sdk.protocol.Parser
 import tbdex.sdk.protocol.models.Message
 import tbdex.sdk.protocol.models.Offering
 import tbdex.sdk.protocol.models.Rfq
@@ -42,7 +43,7 @@ suspend fun createExchange(
     val jsonNode = Json.jsonMapper.readTree(requestBody)
     val rfqJsonString = jsonNode["rfq"].toString()
 
-    rfq = Message.parse(rfqJsonString) as Rfq
+    rfq = Rfq.parse(rfqJsonString)
     if (jsonNode["replyTo"] != null) {
       replyTo = jsonNode["replyTo"].asText()
     }

--- a/httpserver/src/main/kotlin/tbdex/sdk/httpserver/handlers/SubmitMessage.kt
+++ b/httpserver/src/main/kotlin/tbdex/sdk/httpserver/handlers/SubmitMessage.kt
@@ -8,6 +8,7 @@ import tbdex.sdk.httpclient.models.ErrorDetail
 import tbdex.sdk.httpserver.models.Callbacks
 import tbdex.sdk.httpserver.models.ErrorResponse
 import tbdex.sdk.httpserver.models.ExchangesApi
+import tbdex.sdk.protocol.Parser
 import tbdex.sdk.protocol.models.Close
 import tbdex.sdk.protocol.models.Message
 import tbdex.sdk.protocol.models.MessageKind
@@ -30,7 +31,7 @@ suspend fun submitMessage(
   val message: Message
 
   try {
-    message = Message.parse(call.receiveText())
+    message = Parser.parseMessage(call.receiveText())
   } catch (e: Exception) {
     val errorDetail = ErrorDetail(detail = "Parsing of TBDex message failed: ${e.message}")
     val errorResponse = ErrorResponse(listOf(errorDetail))

--- a/httpserver/src/test/kotlin/ServerTest.kt
+++ b/httpserver/src/test/kotlin/ServerTest.kt
@@ -27,7 +27,7 @@ open class ServerTest {
       val serverConfig = TbdexHttpServerConfig(
         port = 8080,
         pfiDid = TestData.pfiDid.uri,
-        balancesEnabled = true
+        balancesApi = FakeBalancesApi(),
       )
       val tbdexServer = TbdexHttpServer(serverConfig)
       tbdexServer.configure(this)

--- a/httpserver/src/test/kotlin/tbdex/sdk/httpserver/handlers/GetBalancesTest.kt
+++ b/httpserver/src/test/kotlin/tbdex/sdk/httpserver/handlers/GetBalancesTest.kt
@@ -106,7 +106,7 @@ class GetBalancesTest {
       val jsonNode = Json.jsonMapper.readTree(responseString)
       val balances = jsonNode.get("data").elements().asSequence()
         .map { balance ->
-          Resource.parse(balance.toString())
+          Balance.parse(balance.toString())
         }
         .toList()
 

--- a/httpserver/src/test/kotlin/tbdex/sdk/httpserver/handlers/GetExchangeTest.kt
+++ b/httpserver/src/test/kotlin/tbdex/sdk/httpserver/handlers/GetExchangeTest.kt
@@ -26,6 +26,7 @@ import tbdex.sdk.httpclient.RequestToken
 import tbdex.sdk.httpserver.models.ErrorResponse
 import tbdex.sdk.httpserver.models.ExchangesApi
 import tbdex.sdk.httpserver.models.GetExchangeCallback
+import tbdex.sdk.protocol.Parser
 import tbdex.sdk.protocol.models.Message
 import tbdex.sdk.protocol.models.Rfq
 import tbdex.sdk.protocol.serialization.Json
@@ -101,7 +102,7 @@ class GetExchangeTest {
       val exchange = jsonNode.get("data").elements().asSequence()
         .map {
           val string = it.toString()
-          Message.parse(string)
+          Parser.parseMessage(string)
         }.toList()
 
       assertEquals((exchange[0] as Rfq).metadata.from, TestData.aliceDid.uri)

--- a/httpserver/src/test/kotlin/tbdex/sdk/httpserver/handlers/GetExchangesTest.kt
+++ b/httpserver/src/test/kotlin/tbdex/sdk/httpserver/handlers/GetExchangesTest.kt
@@ -27,6 +27,7 @@ import tbdex.sdk.httpserver.models.ErrorResponse
 import tbdex.sdk.httpserver.models.ExchangesApi
 import tbdex.sdk.httpserver.models.GetExchangesCallback
 import tbdex.sdk.httpserver.models.GetExchangesFilter
+import tbdex.sdk.protocol.Parser
 import tbdex.sdk.protocol.models.Message
 import tbdex.sdk.protocol.serialization.Json
 import web5.sdk.crypto.InMemoryKeyManager
@@ -105,7 +106,7 @@ class GetExchangesTest {
         .map { exchange ->
           exchange.elements().asSequence().map {
             val string = it.toString()
-            Message.parse(string)
+            Parser.parseMessage(string)
           }.toList()
         }
         .toList()

--- a/protocol/src/main/kotlin/tbdex/sdk/protocol/Parser.kt
+++ b/protocol/src/main/kotlin/tbdex/sdk/protocol/Parser.kt
@@ -1,0 +1,152 @@
+package tbdex.sdk.protocol
+
+import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.databind.JsonNode
+import tbdex.sdk.protocol.models.Balance
+import tbdex.sdk.protocol.models.Close
+import tbdex.sdk.protocol.models.Message
+import tbdex.sdk.protocol.models.MessageKind
+import tbdex.sdk.protocol.models.Offering
+import tbdex.sdk.protocol.models.Order
+import tbdex.sdk.protocol.models.OrderStatus
+import tbdex.sdk.protocol.models.Quote
+import tbdex.sdk.protocol.models.Resource
+import tbdex.sdk.protocol.models.ResourceKind
+import tbdex.sdk.protocol.models.Rfq
+import tbdex.sdk.protocol.serialization.Json
+
+/**
+ * Utility functions for parsing TBDex Messages and Resources
+ */
+object Parser {
+  /**
+   * Takes an existing Message in the form of a json string and parses it into a Message object.
+   * Validates object structure and performs an integrity check using the message signature.
+   *
+   * @param payload The message as a json string.
+   * @return The json string parsed into a concrete Message implementation.
+   * @throws IllegalArgumentException if the payload is not valid json.
+   * @throws IllegalArgumentException if the payload does not conform to the expected json schema.
+   * @throws IllegalArgumentException if the payload signature verification fails.
+   */
+  fun parseMessage(payload: String): Message {
+    val jsonMessage = parseMessageToJsonNode(payload)
+    val kind = jsonMessage.get("metadata").get("kind").asText()
+
+    val messageType = when (MessageKind.valueOf(kind)) {
+      MessageKind.rfq -> Rfq::class.java
+      MessageKind.order -> Order::class.java
+      MessageKind.orderstatus -> OrderStatus::class.java
+      MessageKind.quote -> Quote::class.java
+      MessageKind.close -> Close::class.java
+    }
+
+    val message = Json.jsonMapper.convertValue(jsonMessage, messageType)
+    message.verify()
+
+    return message
+  }
+
+  /**
+   * Takes an existing Message in the form of a json string and parses it into a JsonNode object.
+   * Validates object structure.
+   *
+   * @param payload The message as a json string.
+   * @return The json string parsed into a JsonNode object.
+   * @throws IllegalArgumentException if the payload is not valid json.
+   * @throws IllegalArgumentException if the payload does not conform to the expected json schema.
+   */
+  fun parseMessageToJsonNode(payload: String): JsonNode {
+    val jsonMessage: JsonNode
+
+    try {
+      jsonMessage = Json.jsonMapper.readTree(payload)
+    } catch (e: JsonParseException) {
+      throw IllegalArgumentException("unexpected character at offset ${e.location.charOffset}")
+    }
+
+    require(jsonMessage.isObject) { "expected payload to be a json object" }
+
+    // validate message structure
+    Validator.validate(jsonMessage, "message")
+
+    val jsonMessageData = jsonMessage.get("data")
+    val kind = jsonMessage.get("metadata").get("kind").asText()
+
+    // validate specific message data (Rfq, Quote, etc)
+    Validator.validate(jsonMessageData, kind)
+
+    return jsonMessage
+  }
+
+  /**
+   * Takes an existing Resource in the form of a json string and parses it into a Resource object.
+   * Validates object structure and performs an integrity check using the resource signature.
+   *
+   * @param payload The resource as a json string.
+   * @return The json string parsed into a concrete Resource implementation.
+   * @throws IllegalArgumentException if the payload is not valid json.
+   * @throws IllegalArgumentException if the payload does not conform to the expected json schema.
+   * @throws IllegalArgumentException if the payload signature verification fails.
+   */
+  fun parseResource(payload: String): Resource {
+    val jsonResource: JsonNode = try {
+      Json.jsonMapper.readTree(payload)
+    } catch (e: JsonParseException) {
+      throw IllegalArgumentException("unexpected character at offset ${e.location.charOffset}")
+    }
+
+    require(jsonResource.isObject) { "expected payload to be a json object" }
+
+    // validate message structure
+    Validator.validate(jsonResource, "resource")
+
+    val dataJson = jsonResource.get("data")
+    val kind = jsonResource.get("metadata").get("kind").asText()
+
+    // validate specific resource data
+    Validator.validate(dataJson, kind)
+
+    val resourceType = when (ResourceKind.valueOf(kind)) {
+      ResourceKind.offering -> Offering::class.java
+      ResourceKind.balance -> Balance::class.java
+    }
+
+    val resource = Json.jsonMapper.convertValue(jsonResource, resourceType)
+    resource.verify()
+
+    return resource
+  }
+
+  /**
+   * Takes an existing REsource in the form of a json string and parses it into a JsonNode object.
+   * Validates object structure.
+   *
+   * @param payload The resource as a json string.
+   * @return The json string parsed into a JsonNode object.
+   * @throws IllegalArgumentException if the payload is not valid json.
+   * @throws IllegalArgumentException if the payload does not conform to the expected json schema.
+   */
+  fun parseResourceToJsonNode(payload: String): JsonNode {
+    val jsonResource: JsonNode
+
+    try {
+      jsonResource = Json.jsonMapper.readTree(payload)
+    } catch (e: JsonParseException) {
+      throw IllegalArgumentException("unexpected character at offset ${e.location.charOffset}")
+    }
+
+    require(jsonResource.isObject) { "expected payload to be a json object" }
+
+    // validate resource structure
+    Validator.validate(jsonResource, "resource")
+
+    val jsonResourceData = jsonResource.get("data")
+    val kind = jsonResource.get("metadata").get("kind").asText()
+
+    // validate specific message data (Rfq, Quote, etc)
+    Validator.validate(jsonResourceData, kind)
+
+    return jsonResource
+  }
+}

--- a/protocol/src/main/kotlin/tbdex/sdk/protocol/models/Balance.kt
+++ b/protocol/src/main/kotlin/tbdex/sdk/protocol/models/Balance.kt
@@ -1,7 +1,9 @@
 package tbdex.sdk.protocol.models
 
 import de.fxlae.typeid.TypeId
+import tbdex.sdk.protocol.Parser
 import tbdex.sdk.protocol.Validator
+import tbdex.sdk.protocol.serialization.Json
 import java.time.OffsetDateTime
 
 /**
@@ -32,7 +34,19 @@ class Balance(
      * @param payload The Balance as a json string.
      * @return The json string parsed into a concrete Balance implementation.
      */
-    fun parse(payload: String) = Resource.parse(payload) as Balance
+    fun parse(payload: String): Balance {
+      val jsonResource = Parser.parseResourceToJsonNode(payload)
+
+      val kind = jsonResource.get("metadata").get("kind").asText()
+      if (kind != "balance") {
+        throw IllegalArgumentException("Message must be an Balance but resource kind was $kind")
+      }
+
+      val resource = Json.jsonMapper.convertValue(jsonResource, Balance::class.java)
+      resource.verify()
+
+      return resource
+    }
 
     /**
      * Creates a new `Balance` resource, autopopulating the id, creation/updated time, and resource kind.

--- a/protocol/src/main/kotlin/tbdex/sdk/protocol/models/Offering.kt
+++ b/protocol/src/main/kotlin/tbdex/sdk/protocol/models/Offering.kt
@@ -1,10 +1,12 @@
 package tbdex.sdk.protocol.models
 
 import de.fxlae.typeid.TypeId
+import tbdex.sdk.protocol.Parser
 import tbdex.sdk.protocol.Validator
 import tbdex.sdk.protocol.models.Close.Companion.create
 import tbdex.sdk.protocol.models.Offering.Companion.create
 import tbdex.sdk.protocol.models.Order.Companion.create
+import tbdex.sdk.protocol.serialization.Json
 import java.time.OffsetDateTime
 
 /**
@@ -29,14 +31,6 @@ class Offering private constructor(
   override var signature: String? = null
 ) : Resource() {
   companion object {
-    /**
-     * Takes an existing Offering in the form of a json string and parses it into an Offering object.
-     * Validates object structure and performs an integrity check using the signature.
-     *
-     * @param payload The offering as a json string.
-     * @return The json string parsed into a concrete Offering implementation.
-     */
-    fun parse(payload: String) = Resource.parse(payload) as Offering
 
     /**
      * Creates a new `Offering` resource, autopopulating the id, creation/updated time, and resource kind.
@@ -59,6 +53,31 @@ class Offering private constructor(
       Validator.validateData(data, "offering")
 
       return Offering(metadata, data)
+    }
+
+    /**
+     * Takes an existing Offering in the form of a json string and parses it into an Offering object.
+     * Validates object structure and performs an integrity check using the resource signature.
+     *
+     * @param payload The Offering as a json string.
+     * @return The json string parsed into an Offering
+     * @throws IllegalArgumentException if the payload is not valid json.
+     * @throws IllegalArgumentException if the payload does not conform to the expected json schema.
+     * @throws IllegalArgumentException if the payload signature verification fails.
+     * @throws IllegalArgumentException if the payload is not an Offering
+     */
+    fun parse(payload: String): Offering {
+      val jsonResource = Parser.parseResourceToJsonNode(payload)
+
+      val kind = jsonResource.get("metadata").get("kind").asText()
+      if (kind != "offering") {
+        throw IllegalArgumentException("Message must be an Offering but resource kind was $kind")
+      }
+
+      val resource = Json.jsonMapper.convertValue(jsonResource, Offering::class.java)
+      resource.verify()
+
+      return resource
     }
   }
 }

--- a/protocol/src/test/kotlin/tbdex/sdk/protocol/TbdexTestVectorsProtocol.kt
+++ b/protocol/src/test/kotlin/tbdex/sdk/protocol/TbdexTestVectorsProtocol.kt
@@ -77,7 +77,7 @@ class TbdexTestVectorsProtocol {
     val input = vector["input"].textValue()
     assertNotNull(input)
 
-    val tbDEXMessage = Message.parse(input)
+    val tbDEXMessage = Parser.parseMessage(input)
     assertIs<T>(tbDEXMessage)
 
     assertEquals(vector["output"], Json.jsonMapper.readTree(tbDEXMessage.toString()))
@@ -87,7 +87,7 @@ class TbdexTestVectorsProtocol {
     val input = vector["input"].textValue()
     assertNotNull(input)
 
-    val tbDEXMessage = Resource.parse(input)
+    val tbDEXMessage = Parser.parseResource(input)
     assertIs<T>(tbDEXMessage)
 
     assertEquals(vector["output"], Json.jsonMapper.readTree(tbDEXMessage.toString()))
@@ -97,6 +97,6 @@ class TbdexTestVectorsProtocol {
   // private fun testErrorTestVector(vector: JsonNode) {
   //   val input = vector["input"].textValue()
   //   assertNotNull(input)
-  //   assertThrows(Message.parse(vector["input"])
+  //   assertThrows(Parser.parseMessage(vector["input"])
   // }
 }

--- a/protocol/src/test/kotlin/tbdex/sdk/protocol/models/BalanceTest.kt
+++ b/protocol/src/test/kotlin/tbdex/sdk/protocol/models/BalanceTest.kt
@@ -35,7 +35,7 @@ class BalanceTest {
     val balance = TestData.getBalance()
     balance.sign(TestData.PFI_DID)
     val jsonResource = balance.toString()
-    val parsedBalance = Resource.parse(jsonResource)
+    val parsedBalance = Balance.parse(jsonResource)
 
     assertIs<Balance>(parsedBalance)
     assertThat(parsedBalance.toString()).isEqualTo(jsonResource)
@@ -46,7 +46,7 @@ class BalanceTest {
     val balance = TestData.getBalance()
     balance.sign(TestData.PFI_DID)
 
-    val parsedBalance = assertDoesNotThrow { Resource.parse(Json.stringify(balance)) }
+    val parsedBalance = assertDoesNotThrow { Balance.parse(Json.stringify(balance)) }
     assertIs<Balance>(parsedBalance)
   }
 

--- a/protocol/src/test/kotlin/tbdex/sdk/protocol/models/CloseTest.kt
+++ b/protocol/src/test/kotlin/tbdex/sdk/protocol/models/CloseTest.kt
@@ -8,6 +8,7 @@ import assertk.assertions.startsWith
 import com.nimbusds.jose.JWSObject
 import de.fxlae.typeid.TypeId
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 import tbdex.sdk.protocol.TestData
 import tbdex.sdk.protocol.serialization.Json
 import kotlin.test.Test
@@ -45,10 +46,18 @@ class CloseTest {
     val close = TestData.getClose()
     close.sign(TestData.PFI_DID)
     val jsonMessage = close.toString()
-    val parsedMessage = Message.parse(jsonMessage)
+    val parsedMessage = Close.parse(jsonMessage)
 
     assertIs<Close>(parsedMessage)
     assertThat(parsedMessage.toString()).isEqualTo(jsonMessage)
+  }
+
+  @Test
+  fun `parse() throws if json string is not a Close`() {
+    val quote = TestData.getQuote()
+    quote.sign(TestData.ALICE_DID)
+    val jsonMessage = quote.toString()
+    assertThrows<IllegalArgumentException> { Close.parse(jsonMessage) }
   }
 
   @Test
@@ -56,6 +65,6 @@ class CloseTest {
     val close = TestData.getClose()
     close.sign(TestData.PFI_DID)
 
-    assertDoesNotThrow { Message.parse(Json.stringify(close)) }
+    assertDoesNotThrow { Close.parse(Json.stringify(close)) }
   }
 }

--- a/protocol/src/test/kotlin/tbdex/sdk/protocol/models/OfferingTest.kt
+++ b/protocol/src/test/kotlin/tbdex/sdk/protocol/models/OfferingTest.kt
@@ -5,6 +5,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.startsWith
 import org.junit.jupiter.api.assertDoesNotThrow
+import tbdex.sdk.protocol.Parser
 import tbdex.sdk.protocol.TestData
 import tbdex.sdk.protocol.serialization.Json
 import kotlin.test.Test
@@ -36,7 +37,7 @@ class OfferingTest {
     val offering = TestData.getOffering()
     offering.sign(TestData.PFI_DID)
     val jsonResource = offering.toString()
-    val parsed = Resource.parse(jsonResource)
+    val parsed = Parser.parseResource(jsonResource)
 
     assertIs<Offering>(parsed)
     assertThat(parsed.toString()).isEqualTo(jsonResource)
@@ -47,7 +48,7 @@ class OfferingTest {
     val offering = TestData.getOffering()
     offering.sign(TestData.PFI_DID)
 
-    val parsedOffering = assertDoesNotThrow { Resource.parse(Json.stringify(offering)) }
+    val parsedOffering = assertDoesNotThrow { Parser.parseResource(Json.stringify(offering)) }
     assertIs<Offering>(parsedOffering)
   }
 

--- a/protocol/src/test/kotlin/tbdex/sdk/protocol/models/OrderStatusTest.kt
+++ b/protocol/src/test/kotlin/tbdex/sdk/protocol/models/OrderStatusTest.kt
@@ -6,6 +6,8 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.startsWith
 import de.fxlae.typeid.TypeId
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import tbdex.sdk.protocol.Parser
 import tbdex.sdk.protocol.TestData
 import tbdex.sdk.protocol.serialization.Json
 import kotlin.test.Test
@@ -33,10 +35,18 @@ class OrderStatusTest {
     val orderStatus = TestData.getOrderStatus()
     orderStatus.sign(TestData.PFI_DID)
     val jsonMessage = orderStatus.toString()
-    val parsedMessage = Message.parse(jsonMessage)
+    val parsedMessage = OrderStatus.parse(jsonMessage)
 
     assertIs<OrderStatus>(parsedMessage)
     assertThat(parsedMessage.toString()).isEqualTo(jsonMessage)
+  }
+
+  @Test
+  fun `parse() throws if json string is not an OrderStatus`() {
+    val quote = TestData.getQuote()
+    quote.sign(TestData.ALICE_DID)
+    val jsonMessage = quote.toString()
+    assertThrows<IllegalArgumentException> { OrderStatus.parse(jsonMessage) }
   }
 
   @Test
@@ -44,6 +54,6 @@ class OrderStatusTest {
     val orderStatus = TestData.getOrderStatus()
     orderStatus.sign(TestData.PFI_DID)
 
-    assertDoesNotThrow { Message.parse(Json.stringify(orderStatus)) }
+    assertDoesNotThrow { OrderStatus.parse(Json.stringify(orderStatus)) }
   }
 }

--- a/protocol/src/test/kotlin/tbdex/sdk/protocol/models/OrderTest.kt
+++ b/protocol/src/test/kotlin/tbdex/sdk/protocol/models/OrderTest.kt
@@ -7,6 +7,8 @@ import assertk.assertions.startsWith
 import de.fxlae.typeid.TypeId
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import tbdex.sdk.protocol.Parser
 import tbdex.sdk.protocol.TestData
 import tbdex.sdk.protocol.serialization.Json
 import kotlin.test.Test
@@ -32,10 +34,18 @@ class OrderTest {
     val order = TestData.getOrder()
     order.sign(TestData.ALICE_DID)
     val jsonMessage = order.toString()
-    val parsedMessage = Message.parse(jsonMessage)
+    val parsedMessage = Order.parse(jsonMessage)
 
     assertIs<Order>(parsedMessage)
     assertThat(parsedMessage.toString()).isEqualTo(jsonMessage)
+  }
+
+  @Test
+  fun `parse() throws if json string is not an Order`() {
+    val quote = TestData.getQuote()
+    quote.sign(TestData.ALICE_DID)
+    val jsonMessage = quote.toString()
+    assertThrows<IllegalArgumentException> { Order.parse(jsonMessage) }
   }
 
   @Test
@@ -43,6 +53,6 @@ class OrderTest {
     val order = TestData.getOrder()
     order.sign(TestData.ALICE_DID)
 
-    assertDoesNotThrow { Message.parse(Json.stringify(order)) }
+    assertDoesNotThrow { Order.parse(Json.stringify(order)) }
   }
 }

--- a/protocol/src/test/kotlin/tbdex/sdk/protocol/models/QuoteTest.kt
+++ b/protocol/src/test/kotlin/tbdex/sdk/protocol/models/QuoteTest.kt
@@ -6,6 +6,8 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.startsWith
 import de.fxlae.typeid.TypeId
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import tbdex.sdk.protocol.Parser
 import tbdex.sdk.protocol.TestData
 import tbdex.sdk.protocol.serialization.Json
 import java.time.OffsetDateTime
@@ -38,10 +40,18 @@ class QuoteTest {
     val quote = TestData.getQuote()
     quote.sign(TestData.PFI_DID)
     val jsonMessage = quote.toString()
-    val parsedMessage = Message.parse(jsonMessage)
+    val parsedMessage = Quote.parse(jsonMessage)
 
     assertIs<Quote>(parsedMessage)
     assertThat(parsedMessage.toString()).isEqualTo(jsonMessage)
+  }
+
+  @Test
+  fun `parse() throws if json string is not a Quote`() {
+    val rfq = TestData.getRfq()
+    rfq.sign(TestData.ALICE_DID)
+    val jsonMessage = rfq.toString()
+    assertThrows<IllegalArgumentException> { Quote.parse(jsonMessage) }
   }
 
   @Test
@@ -49,7 +59,7 @@ class QuoteTest {
     val quote = TestData.getQuote()
     quote.sign(TestData.PFI_DID)
 
-    assertDoesNotThrow { Message.parse(Json.stringify(quote)) }
+    assertDoesNotThrow { Quote.parse(Json.stringify(quote)) }
   }
 }
 

--- a/protocol/src/test/kotlin/tbdex/sdk/protocol/models/ResourceTest.kt
+++ b/protocol/src/test/kotlin/tbdex/sdk/protocol/models/ResourceTest.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isNotNull
 import com.nimbusds.jose.JWSObject
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import tbdex.sdk.protocol.Parser
 import tbdex.sdk.protocol.TestData
 import tbdex.sdk.protocol.ValidatorException
 import tbdex.sdk.protocol.serialization.Json
@@ -43,7 +44,7 @@ class ResourceTest {
 
   @Test
   fun `parse throws error if json string is not valid`() {
-    assertThrows<IllegalArgumentException> { Resource.parse(";;;;") }
+    assertThrows<IllegalArgumentException> { Parser.parseResource(";;;;") }
   }
 
   @Test
@@ -52,7 +53,7 @@ class ResourceTest {
     // do not sign it
 
     val exception = assertThrows<ValidatorException> {
-      Resource.parse(Json.stringify(offeringFromPfi))
+      Offering.parse(Json.stringify(offeringFromPfi))
     }
     assertThat(exception.message!!).contains(
       "invalid payload."
@@ -65,7 +66,7 @@ class ResourceTest {
     // do not sign it
 
     val exception = assertThrows<ValidatorException> {
-      Resource.parse(Json.stringify(balanceFromPfi))
+      Offering.parse(Json.stringify(balanceFromPfi))
     }
     assertThat(exception.message!!).contains(
       "invalid payload."
@@ -79,7 +80,7 @@ class ResourceTest {
     offeringFromPfi.sign(TestData.ALICE_DID)
 
     val exception = assertThrows<SignatureException> {
-      Resource.parse(Json.stringify(offeringFromPfi))
+      Parser.parseResource(Json.stringify(offeringFromPfi))
     }
     assertThat(exception.message!!).contains(
       "Signature verification failed: Was not signed by the expected DID"
@@ -93,7 +94,7 @@ class ResourceTest {
     balanceFromPfi.sign(TestData.ALICE_DID)
 
     val exception = assertThrows<SignatureException> {
-      Resource.parse(Json.stringify(balanceFromPfi))
+      Balance.parse(Json.stringify(balanceFromPfi))
     }
     assertThat(exception.message!!).contains("Signature verification failed: Was not signed by the expected DID")
   }

--- a/protocol/src/test/kotlin/tbdex/sdk/protocol/models/RfqTest.kt
+++ b/protocol/src/test/kotlin/tbdex/sdk/protocol/models/RfqTest.kt
@@ -41,10 +41,18 @@ class RfqTest {
     val rfq = TestData.getRfq()
     rfq.sign(TestData.ALICE_DID)
     val jsonMessage = rfq.toString()
-    val parsedMessage = Message.parse(jsonMessage)
+    val parsedMessage = Rfq.parse(jsonMessage)
 
     assertIs<Rfq>(parsedMessage)
     assertThat(parsedMessage.toString()).isEqualTo(jsonMessage)
+  }
+
+  @Test
+  fun `parse() throws if json string is not an Rfq`() {
+    val quote = TestData.getQuote()
+    quote.sign(TestData.ALICE_DID)
+    val jsonMessage = quote.toString()
+    assertThrows<IllegalArgumentException> { Rfq.parse(jsonMessage) }
   }
 
   @Test
@@ -52,7 +60,7 @@ class RfqTest {
     val rfq = TestData.getRfq()
     rfq.sign(TestData.ALICE_DID)
 
-    assertDoesNotThrow { Message.parse(Json.stringify(rfq)) }
+    assertDoesNotThrow { Rfq.parse(Json.stringify(rfq)) }
   }
 
   @Test


### PR DESCRIPTION
* Create specific message parsers e.g. `Rfq.parse()` which will ensure the payload is an RFQ message and can be easily extended to do RFQ-specific validation
* Move `Message.parse()` into `Parser.parseMessage()` because `Message.parse()` caused `Message` to depend on its subclasses, which is a violation of OOP best practices and constitutes a circular dependency.