### PR TITLE
Avoid CVE-2024-29025

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,6 @@ buildscript {
     resolutionStrategy {
       // Address https://github.com/TBD54566975/tbdex-kt/issues/167
       force("com.fasterxml.woodstox:woodstox-core:6.4.0")
-      force("io.netty:netty-codec-http:4.1.108Final")
     }
   }
 }
@@ -90,6 +89,8 @@ allprojects {
       force("com.google.protobuf:protobuf-javalite:3.19.6")
       // Addresses https://github.com/TBD54566975/tbdex-kt/issues/170
       force("com.squareup.okio:okio:3.6.0")
+      // Addresses CVE-2024-29025
+      force("io.netty:netty-codec-http:4.1.108.Final")
     }
   }
 }


### PR DESCRIPTION
The problem:
<img width="726" alt="image" src="https://github.com/TBD54566975/tbdex-kt/assets/199891/a5c33802-dd6b-4530-95cb-e4c0e0d84a52">

Validated the `force` works locally:

```
gradle :dependencies | grep 'io.netty:netty-codec-http'
|              +--- io.netty:netty-codec-http2:4.1.101.Final
|              |    \--- io.netty:netty-codec-http:4.1.101.Final -> 4.1.108.Final
|              +--- io.netty:netty-codec-http2:4.1.101.Final
|              |    \--- io.netty:netty-codec-http:4.1.101.Final -> 4.1.108.Final
```

Wait on PR checks here to ensure FOSSA is happy in all build environments before merging.