### PR TITLE
Consume web5-kt 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     the version "version.xyz.block.web5" set this web5-parent. When updating Web5, update both
     this version *and* the <version.xyz.block.web5> below in the <properties> section.
     -->
-    <version>1.0.0</version>
+    <version>1.1.0</version>
   </parent>
   <name>tbDEX SDK for the JVM Build Parent</name>
   <url>https://developer.tbd.website</url>
@@ -102,7 +102,7 @@
     this version to refer to the web5-parent at the top of this file. When updating
     Web5, update both here and in the <parent> declaration above.
     -->
-    <version.xyz.block.web5>1.0.0</version.xyz.block.web5>
+    <version.xyz.block.web5>1.1.0</version.xyz.block.web5>
 
     <!-- Versioning for Dependencies -->
     <version.de.fxlae>0.2.0</version.de.fxlae>


### PR DESCRIPTION
This will consume web5-kt 1.0.0

This change has `credentialSchema` field in the vc data model