### PR TITLE
bump `web5` to `2.0.0`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     the version "version.xyz.block.web5" set this web5-parent. When updating Web5, update both
     this version *and* the <version.xyz.block.web5> below in the <properties> section.
     -->
-    <version>1.1.2</version>
+    <version>2.0.0</version>
   </parent>
   <name>tbDEX SDK for the JVM Build Parent</name>
   <url>https://developer.tbd.website</url>
@@ -102,7 +102,7 @@
     this version to refer to the web5-parent at the top of this file. When updating
     Web5, update both here and in the <parent> declaration above.
     -->
-    <version.xyz.block.web5>1.1.2</version.xyz.block.web5>
+    <version.xyz.block.web5>2.0.0</version.xyz.block.web5>
 
     <!-- Versioning for Dependencies -->
     <version.de.fxlae>0.2.0</version.de.fxlae>


### PR DESCRIPTION
this will be a major version release of `tbdex-kt`. specifically, `2.0.0`

> [!IMPORTANT]
> `xyz.block:web5:2.0.0` was just released so CI will likely fail until it gets mirrored to maven central